### PR TITLE
feat: added OKLch and OKLab to color nodes

### DIFF
--- a/src/nodes/color/create.ts
+++ b/src/nodes/color/create.ts
@@ -10,6 +10,8 @@ export const colorSpaces = [
 	'hsi',
 	'lab',
 	'lch',
+	'oklab',
+	'oklch',
 	'hcl',
 	'cmyk',
 	'gl'

--- a/src/nodes/color/lib/darken.ts
+++ b/src/nodes/color/lib/darken.ts
@@ -16,6 +16,15 @@ export function darken(
       color.set("lch.c", newChroma);
       return color;
     }
+    case ColorSpaceTypes.OKLCH: {
+      const lightness = color.oklch.l;
+      const difference = lightness;
+      const newChroma = Math.max(0, color.oklch.c - amount * color.oklch.c);
+      const newLightness = Math.max(0, lightness - difference * amount);
+      color.set("oklch.l", newLightness);
+      color.set("oklch.c", newChroma);
+      return color;
+    }
     case ColorSpaceTypes.HSL: {
       const lightness = color.hsl.l;
       const difference = lightness;

--- a/src/nodes/color/lib/lighten.ts
+++ b/src/nodes/color/lib/lighten.ts
@@ -16,6 +16,15 @@ export function lighten(
       color.set("lch.c", newChroma);
       return color;
     }
+    case ColorSpaceTypes.OKLCH: {
+      const lightness = color.oklch.l;
+      const difference = 100 - lightness;
+      const newChroma = Math.max(0, color.oklch.c - amount * color.oklch.c);
+      const newLightness = Math.min(100, lightness + difference * amount);
+      color.set("oklch.l", newLightness);
+      color.set("oklch.c", newChroma);
+      return color;
+    }
     case ColorSpaceTypes.HSL: {
       const lightness = color.hsl.l;
       const difference = 100 - lightness;

--- a/src/nodes/color/lib/types.ts
+++ b/src/nodes/color/lib/types.ts
@@ -1,6 +1,7 @@
 import { ColorModifierTypes } from "@tokens-studio/types";
 
 export enum ColorSpaceTypes {
+  OKLCH = "oklch",
   LCH = "lch",
   SRGB = "srgb",
   P3 = "p3",


### PR DESCRIPTION
## Overview
* Added OKLch option for lighten and darken nodes
* Added OKLch and OKLab options for create color node

## Motivation
OKLab and OKLch are modern color spaces that are optimized for perceptual uniformity in computer displays and have become available in design systems (from authoring tools to CSS color support). Designers may wish to add or modify colors using these options for more perceptually uniform control over color appearance.

## Isn't the L* value for OKLab the same as Lab?
Yes this is correct. However, when lightening and darkening a color, the chroma and hue appearance differs between the two color spaces. This is most evident when looking at pure blue, which in Lab becomes a purplish color as it lightens (Abney effect). OKLab corrects these perceptual irregularities to ensure hue and chroma appear constant as lightness changes.

## Has this update been tested?
There was no clear way for me to see and test this within the graph visualization itself. If there is a way to do so, I would gladly test it out. However, in the interim, OKLab and OKLch are both supported by the two color libraries used in the graph editor (chroma.js for create color and colorjs.io for lighten and darken). Theoretically, these should work as expected.