### PR TITLE
fix menu tooltips

### DIFF
--- a/packages/graph-editor/src/editor/index.tsx
+++ b/packages/graph-editor/src/editor/index.tsx
@@ -522,7 +522,7 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
             }}
           >
             <ForceUpdateProvider value={forceUpdate}>
-              <Box css={{ display: 'flex', flexDirection: 'row' }}>
+              <Box css={{ display: 'flex', flexDirection: 'row', zIndex: 0 }}>
                 <Stack
                   direction="column"
                   gap={2}
@@ -550,7 +550,6 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
                       display: 'flex',
                       flexDirection: 'column',
                       borderRight: '1px solid $borderMuted',
-                      zIndex: 10,
                     }}
                   >
                     <DropPanel groups={[]} items={panelItems} />


### PR DESCRIPTION
Fixes tooltips by properly setting zIndex on the menu

<img width="146" alt="CleanShot 2023-10-05 at 10 16 53@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/eea153a9-7549-4592-ac65-3d03ca14f348">
