### PR TITLE
Fix switch handles

### DIFF
--- a/packages/graph-editor/src/components/flow/handles.tsx
+++ b/packages/graph-editor/src/components/flow/handles.tsx
@@ -112,6 +112,7 @@ export const HandleText = styled(Text, {
     secondary: {
       true: {
         color: '$fgDefault',
+        textTransform: 'none',
       },
     },
   },

--- a/packages/graph-editor/src/components/flow/handles.tsx
+++ b/packages/graph-editor/src/components/flow/handles.tsx
@@ -112,6 +112,10 @@ export const HandleText = styled(Text, {
     secondary: {
       true: {
         color: '$fgDefault',
+      },
+    },
+    caseSensitive: {
+      true: {
         textTransform: 'none',
       },
     },

--- a/packages/graph-editor/src/components/flow/nodes/accessibility/baseFontSizeNode.tsx
+++ b/packages/graph-editor/src/components/flow/nodes/accessibility/baseFontSizeNode.tsx
@@ -46,13 +46,9 @@ const BaseFontSizeNode = (props) => {
       </HandleContainer>
 
       <HandleContainer type="source">
-        <Handle id="fontSizePX">
-          <Text>Font Size Px:</Text>
-          <PreviewNumber value={output?.fontSizePX} />
-        </Handle>
-        <Handle id="fontSizePT">
-          <Text>Font Size Pt:</Text>
-          <PreviewNumber value={output?.fontSizePT} />
+        <Handle id="output">
+          <Text>Font Size:</Text>
+          <PreviewNumber value={output?.output} />
         </Handle>
       </HandleContainer>
     </Stack>

--- a/packages/graph-editor/src/components/flow/nodes/color/colorDistanceNode.tsx
+++ b/packages/graph-editor/src/components/flow/nodes/color/colorDistanceNode.tsx
@@ -33,7 +33,7 @@ const ColorDistanceNode = (props) => {
       <HandleContainer type="source">
         <Handle id="output">
           <Text>Output</Text>
-          <PreviewNumber value={output?.distance} />
+          <PreviewNumber value={output?.output} />
         </Handle>
       </HandleContainer>
     </Stack>

--- a/packages/graph-editor/src/components/flow/nodes/logic/switchNode.tsx
+++ b/packages/graph-editor/src/components/flow/nodes/logic/switchNode.tsx
@@ -59,7 +59,7 @@ const SwitchNode = () => {
         {state?.order.map((key) => {
           return (
             <StyledHandle id={key} key={key}>
-              <HandleText secondary>{key}</HandleText>
+              <HandleText secondary caseSensitive>{key}</HandleText>
 
               <PreviewAny value={input[key]} />
 

--- a/packages/graph-editor/src/components/flow/nodes/math/fluidNode.tsx
+++ b/packages/graph-editor/src/components/flow/nodes/math/fluidNode.tsx
@@ -38,9 +38,9 @@ const FluidValueNode = (props) => {
       </HandleContainer>
 
       <HandleContainer type="source">
-        <Handle id="fluid">
+        <Handle id="output">
           <Text>Fluid</Text>
-          <PreviewNumber value={output?.clamped} />
+          <PreviewNumber value={output?.output} />
         </Handle>
       </HandleContainer>
     </Stack>

--- a/packages/graph-engine/src/nodes/accessibility/baseFontSize.ts
+++ b/packages/graph-engine/src/nodes/accessibility/baseFontSize.ts
@@ -45,20 +45,16 @@ const process = (input: Inputs, state) => {
   const xHeightMM =
     Math.tan((visualCorrection * Math.PI) / 21600) * (distance * 10) * 2;
   const xHeightPX = (xHeightMM / 25.4) * (ppi / pixelDensity);
-  const fontSizePT = (2.83465 * xHeightMM * 1) / xHeightRatio;
+  // const fontSizePT = (2.83465 * xHeightMM * 1) / xHeightRatio;
   const fontSizePX = (1 * xHeightPX) / xHeightRatio;
 
-  return { fontSizePX, fontSizePT };
+  return fontSizePX;
 };
 
-export const mapOutput = (input, state, processed) => {
-  return processed;
-};
 
 export const node: NodeDefinition<Inputs> = {
   description: "Calculates the base font size",
   type,
   defaults,
   process,
-  mapOutput,
 };

--- a/packages/graph-engine/src/nodes/color/distance.ts
+++ b/packages/graph-engine/src/nodes/color/distance.ts
@@ -30,15 +30,11 @@ const process = (input: Inputs, state) => {
 
   const distance = chroma.deltaE(color1, color2);
 
-  return { distance };
+  return distance;
 };
 
-const mapOutput = (input, state, output) => {
-  return output;
-};
 
 export const node: NodeDefinition<Inputs> = {
   type,
-  mapOutput,
   process,
 };

--- a/packages/graph-engine/src/nodes/math/fluid.ts
+++ b/packages/graph-engine/src/nodes/math/fluid.ts
@@ -27,15 +27,10 @@ const process = (input: Inputs, state) => {
   const fluid = (viewport / 100) * fontV + fontR;
   const clamped = Math.min(maxSize, Math.max(minSize, fluid));
 
-  return { clamped };
-};
-
-export const mapOutput = (input, state, processed) => {
-  return processed;
+  return clamped;
 };
 
 export const node: NodeDefinition<Inputs> = {
   type,
   process,
-  mapOutput,
 };


### PR DESCRIPTION
Currently switch handles are displayed in caps which makes it hard to see the real value of them.
This patch removes the text transform from secondary handles to fix this