### PR TITLE
fixes preview code changes not saved back

### DIFF
--- a/.changeset/tall-actors-love.md
+++ b/.changeset/tall-actors-love.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-engine-ui": patch
+---
+
+Fixes Preview code changes not being saved

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -12,14 +12,23 @@ import { LiveEditor, LiveError } from 'react-live';
 import { MinusIcon, PictureInPictureIcon, VideoIcon } from '@iconicicons/react';
 import Code3Icon from '#/assets/svgs/code-3.svg';
 import { useCallback, useState } from 'react';
+import { usePreviewContext } from '#/providers/preview.tsx';
 
 export const Preview = ({ codeRef }) => {
+  const { setCode, code } = usePreviewContext();
   const [isVisible, setIsVisible] = useState(false);
   const [visibleTab, setVisibleTab] = useState('preview');
 
   const handleToggleVisible = useCallback(() => {
     setIsVisible(!isVisible);
   }, [isVisible, setIsVisible]);
+
+  const handleChangeCode = useCallback(
+    (code) => {
+      setCode(code);
+    },
+    [setCode],
+  );
 
   return (
     <Stack
@@ -110,7 +119,7 @@ export const Preview = ({ codeRef }) => {
             <Stack direction="column">
               <LiveError />
               <div ref={codeRef}>
-                <LiveEditor />
+                <LiveEditor onChange={handleChangeCode} />
               </div>
             </Stack>
           </Box>


### PR DESCRIPTION
Fixes a bug where the `Preview` code was not saved.

Before:

https://github.com/tokens-studio/graph-engine/assets/4548309/4827959a-0458-47ca-abae-18e48dcd3421

After:

https://github.com/tokens-studio/graph-engine/assets/4548309/31ea479b-865f-4f1b-85f0-5d9f7bea77ae


