### PR TITLE
Change marker ends to not use arrow heads

### DIFF
--- a/.changeset/swift-lobsters-change.md
+++ b/.changeset/swift-lobsters-change.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Changes markerEnd to not include arrow head

--- a/packages/graph-editor/src/editor/index.tsx
+++ b/packages/graph-editor/src/editor/index.tsx
@@ -91,9 +91,6 @@ const defaultEdgeOptions = {
   style: {
     strokeWidth: 2,
   },
-  markerEnd: {
-    type: MarkerType.ArrowClosed,
-  },
 };
 
 export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(

--- a/packages/graph-engine/tests/data/raw/basic.json
+++ b/packages/graph-engine/tests/data/raw/basic.json
@@ -26,7 +26,6 @@
   "edges": [
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "c15d874f-f7e7-42a6-a6b3-8f238da52007",
       "sourceHandle": "xxx",
       "target": "33952fc4-eced-4c10-a56d-7bdb65182b34",

--- a/packages/graph-engine/tests/data/raw/inputDisconnected.json
+++ b/packages/graph-engine/tests/data/raw/inputDisconnected.json
@@ -46,7 +46,6 @@
   "edges": [
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4e629553-6fe2-444a-8a29-9b30abe26e1b",
       "sourceHandle": "output",
       "target": "5531dd87-f2a0-4e2a-89b9-9d382cd793d9",
@@ -57,7 +56,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "734907ed-5f93-4b34-b24c-f262709470ac",
       "sourceHandle": "colors.tertiary",
       "target": "4e629553-6fe2-444a-8a29-9b30abe26e1b",
@@ -68,7 +66,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "734907ed-5f93-4b34-b24c-f262709470ac",
       "sourceHandle": "colors.primary",
       "target": "4e629553-6fe2-444a-8a29-9b30abe26e1b",

--- a/packages/graph-engine/tests/data/raw/noInput.json
+++ b/packages/graph-engine/tests/data/raw/noInput.json
@@ -37,7 +37,6 @@
   "edges": [
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4e629553-6fe2-444a-8a29-9b30abe26e1b",
       "sourceHandle": "output",
       "target": "5531dd87-f2a0-4e2a-89b9-9d382cd793d9",
@@ -48,7 +47,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "734907ed-5f93-4b34-b24c-f262709470ac",
       "sourceHandle": "colors.tertiary",
       "target": "4e629553-6fe2-444a-8a29-9b30abe26e1b",
@@ -59,7 +57,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "734907ed-5f93-4b34-b24c-f262709470ac",
       "sourceHandle": "colors.primary",
       "target": "4e629553-6fe2-444a-8a29-9b30abe26e1b",

--- a/packages/graph-engine/tests/data/raw/outputObject.json
+++ b/packages/graph-engine/tests/data/raw/outputObject.json
@@ -37,7 +37,6 @@
   "edges": [
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4afda872-881c-4e2b-905c-b5995ad0ebda",
       "sourceHandle": "background",
       "target": "ef251584-99f2-4976-8f0e-e265a12223ce",
@@ -48,7 +47,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ef251584-99f2-4976-8f0e-e265a12223ce",
       "sourceHandle": "output",
       "target": "3a2f6a06-c2a5-4b82-9f93-f9afa00aaacf",

--- a/packages/graph-engine/tests/data/raw/tokenSetInput.json
+++ b/packages/graph-engine/tests/data/raw/tokenSetInput.json
@@ -47,7 +47,6 @@
   "edges": [
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "80182fd6-c10d-4adb-810b-15d555b73c12",
       "sourceHandle": "background-color",
       "target": "413a4ad6-65ca-4d6d-9f68-f12a52ae8185",
@@ -57,7 +56,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "413a4ad6-65ca-4d6d-9f68-f12a52ae8185",
       "sourceHandle": "output",
       "target": "db665864-d7fe-4345-a084-9f020ef5ee9c",
@@ -67,7 +65,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "95b28e18-149f-42df-a61c-891748baeff6",
       "sourceHandle": "colorSet",
       "target": "80182fd6-c10d-4adb-810b-15d555b73c12",

--- a/packages/graph-engine/tests/data/raw/typescale.json
+++ b/packages/graph-engine/tests/data/raw/typescale.json
@@ -809,7 +809,6 @@
   "edges": [
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "24357f64-eea2-4288-ab95-eb2baeba90d0",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -819,7 +818,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-7",
       "target": "59af5d59-53ad-4ad8-b198-583788757f11",
@@ -829,7 +827,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "59af5d59-53ad-4ad8-b198-583788757f11",
@@ -839,7 +836,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "59af5d59-53ad-4ad8-b198-583788757f11",
       "sourceHandle": "output",
       "target": "24357f64-eea2-4288-ab95-eb2baeba90d0",
@@ -849,7 +845,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ab1a116b-11ab-4ce1-88c1-bb7b2eaaeb3d",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -860,7 +855,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "3e0af5e3-774c-4a09-8de1-d95ed6fa4770",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -871,7 +865,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4c0a7fb8-b3dd-4164-8a50-955d2241d3ea",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -882,7 +875,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "944471f5-3720-4940-9e89-f9da2d0ce252",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -893,7 +885,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "98a786e6-8fa9-49a5-a9ee-d41aa8718a2d",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -904,7 +895,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "03f8e7aa-5a71-4699-b70c-e8f6c7b7c89e",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -915,7 +905,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-6",
       "target": "ae63d4c4-57e5-4676-ba6b-091358654d9d",
@@ -926,7 +915,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-5",
       "target": "c59fe168-28a7-41e8-847d-42dde9b460e9",
@@ -937,7 +925,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-4",
       "target": "25c3f410-0911-40d2-9741-7a27b51ede58",
@@ -948,7 +935,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-3",
       "target": "9e267259-2315-4d26-9790-041a2c38844f",
@@ -959,7 +945,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-2",
       "target": "b4317f71-7276-4d96-8e5d-eb17125d0d7a",
@@ -970,7 +955,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-1",
       "target": "9f092600-ba7e-44fe-8416-09f14fc26737",
@@ -981,7 +965,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "ae63d4c4-57e5-4676-ba6b-091358654d9d",
@@ -992,7 +975,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "c59fe168-28a7-41e8-847d-42dde9b460e9",
@@ -1003,7 +985,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "25c3f410-0911-40d2-9741-7a27b51ede58",
@@ -1014,7 +995,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "9e267259-2315-4d26-9790-041a2c38844f",
@@ -1025,7 +1005,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "b4317f71-7276-4d96-8e5d-eb17125d0d7a",
@@ -1036,7 +1015,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "9f092600-ba7e-44fe-8416-09f14fc26737",
@@ -1047,7 +1025,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "9f092600-ba7e-44fe-8416-09f14fc26737",
       "sourceHandle": "output",
       "target": "03f8e7aa-5a71-4699-b70c-e8f6c7b7c89e",
@@ -1058,7 +1035,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b4317f71-7276-4d96-8e5d-eb17125d0d7a",
       "sourceHandle": "output",
       "target": "98a786e6-8fa9-49a5-a9ee-d41aa8718a2d",
@@ -1069,7 +1045,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "9e267259-2315-4d26-9790-041a2c38844f",
       "sourceHandle": "output",
       "target": "944471f5-3720-4940-9e89-f9da2d0ce252",
@@ -1080,7 +1055,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "25c3f410-0911-40d2-9741-7a27b51ede58",
       "sourceHandle": "output",
       "target": "4c0a7fb8-b3dd-4164-8a50-955d2241d3ea",
@@ -1091,7 +1065,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "c59fe168-28a7-41e8-847d-42dde9b460e9",
       "sourceHandle": "output",
       "target": "3e0af5e3-774c-4a09-8de1-d95ed6fa4770",
@@ -1102,7 +1075,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ae63d4c4-57e5-4676-ba6b-091358654d9d",
       "sourceHandle": "output",
       "target": "ab1a116b-11ab-4ce1-88c1-bb7b2eaaeb3d",
@@ -1113,7 +1085,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1b65740f-29c5-49c1-9231-f4fbbb4097c3",
       "sourceHandle": "out",
       "target": "1278e914-c65f-49f0-9fb7-7bc5b4161de7",
@@ -1124,7 +1095,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7da15c1c-a560-47c4-b1fd-1ec80ac52e5f",
       "sourceHandle": null,
       "target": "3b13f3ca-b77f-4af8-a645-e04a6febe4a6",
@@ -1135,7 +1105,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1278e914-c65f-49f0-9fb7-7bc5b4161de7",
       "sourceHandle": "output",
       "target": "7da15c1c-a560-47c4-b1fd-1ec80ac52e5f",
@@ -1146,7 +1115,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
       "sourceHandle": "frequency-0",
       "target": "1278e914-c65f-49f0-9fb7-7bc5b4161de7",
@@ -1157,7 +1125,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "9aa6a2b1-7823-4572-831d-92e4574bfdc8",
       "sourceHandle": "output",
       "target": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
@@ -1168,7 +1135,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "33107a6d-20d7-488a-aa97-51d58125abbd",
       "sourceHandle": "out",
       "target": "9aa6a2b1-7823-4572-831d-92e4574bfdc8",
@@ -1179,7 +1145,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "2e97254a-1782-4426-bc6e-168da9a8e8a8",
       "sourceHandle": "out",
       "target": "9aa6a2b1-7823-4572-831d-92e4574bfdc8",
@@ -1190,7 +1155,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4ae9dbc9-bcf8-4ef8-a14a-afd7ba74afda",
       "sourceHandle": "out",
       "target": "9aa6a2b1-7823-4572-831d-92e4574bfdc8",
@@ -1201,7 +1165,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "755742ec-a01f-4a90-b2d4-1b15ba20099f",
       "sourceHandle": "out",
       "target": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
@@ -1212,7 +1175,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "3703722c-3142-4872-9ac8-d93e0d2ae20b",
       "sourceHandle": "out",
       "target": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
@@ -1223,7 +1185,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "893d5470-f681-4616-9652-5c97bbddf1f4",
       "sourceHandle": "output",
       "target": "bdfaa6bd-7f22-47dd-a0be-b6d997d99786",
@@ -1234,7 +1195,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "87c271ef-4419-4968-8b89-e493abb6a703",
       "sourceHandle": "output",
       "target": "893d5470-f681-4616-9652-5c97bbddf1f4",
@@ -1245,7 +1205,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "82ee4f3e-7f76-4d0b-8fec-37f92d7906ae",
       "sourceHandle": "output",
       "target": "893d5470-f681-4616-9652-5c97bbddf1f4",
@@ -1256,7 +1215,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "xHeightRatio",
       "target": "87c271ef-4419-4968-8b89-e493abb6a703",
@@ -1267,7 +1225,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "47ac6058-1544-4bc3-95aa-aaeea09614cf",
       "sourceHandle": "output",
       "target": "87c271ef-4419-4968-8b89-e493abb6a703",
@@ -1278,7 +1235,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "383211be-3c93-40e5-b510-85ecc5e6672e",
       "sourceHandle": "out",
       "target": "47ac6058-1544-4bc3-95aa-aaeea09614cf",
@@ -1289,7 +1245,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4e169bb1-56e4-47a3-a083-e0eec21d4317",
       "sourceHandle": "output",
       "target": "47ac6058-1544-4bc3-95aa-aaeea09614cf",
@@ -1300,7 +1255,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "xHeightRatio",
       "target": "82ee4f3e-7f76-4d0b-8fec-37f92d7906ae",
@@ -1311,7 +1265,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "0c44adc6-2f64-42e6-a3f5-f08bf4959eac",
       "sourceHandle": "output",
       "target": "82ee4f3e-7f76-4d0b-8fec-37f92d7906ae",
@@ -1322,7 +1275,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "383211be-3c93-40e5-b510-85ecc5e6672e",
       "sourceHandle": "out",
       "target": "0c44adc6-2f64-42e6-a3f5-f08bf4959eac",
@@ -1333,7 +1285,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ed7a3237-8d72-402e-a2f9-822c359bca61",
       "sourceHandle": "out",
       "target": "0c44adc6-2f64-42e6-a3f5-f08bf4959eac",
@@ -1344,7 +1295,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1473a6ed-fb5c-4224-8de1-0d2183650122",
       "sourceHandle": "output",
       "target": "0c44adc6-2f64-42e6-a3f5-f08bf4959eac",
@@ -1355,7 +1305,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "06a87cdb-6620-4660-a292-f15a97dc75be",
       "sourceHandle": "out",
       "target": "893d5470-f681-4616-9652-5c97bbddf1f4",
@@ -1366,7 +1315,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00267679-f30e-4b65-b0e2-8be2fc5e6f7f",
       "sourceHandle": "output",
       "target": "4e169bb1-56e4-47a3-a083-e0eec21d4317",
@@ -1377,7 +1325,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7d632ca6-bab7-49cb-af21-eb08c6033117",
       "sourceHandle": "out",
       "target": "00267679-f30e-4b65-b0e2-8be2fc5e6f7f",
@@ -1388,7 +1335,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1473a6ed-fb5c-4224-8de1-0d2183650122",
       "sourceHandle": "output",
       "target": "00267679-f30e-4b65-b0e2-8be2fc5e6f7f",
@@ -1399,7 +1345,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "6944a35e-1f24-464b-b5c6-1ccb67d53408",
       "sourceHandle": "output",
       "target": "4e169bb1-56e4-47a3-a083-e0eec21d4317",
@@ -1410,7 +1355,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7d632ca6-bab7-49cb-af21-eb08c6033117",
       "sourceHandle": "out",
       "target": "294619a8-f446-4184-aaaf-de7f8b10ab8c",
@@ -1421,7 +1365,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1473a6ed-fb5c-4224-8de1-0d2183650122",
       "sourceHandle": "output",
       "target": "294619a8-f446-4184-aaaf-de7f8b10ab8c",
@@ -1432,7 +1375,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "pixelDensity",
       "target": "6944a35e-1f24-464b-b5c6-1ccb67d53408",
@@ -1443,7 +1385,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "ppi",
       "target": "6944a35e-1f24-464b-b5c6-1ccb67d53408",
@@ -1454,7 +1395,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "5064c342-b8b6-4a6a-b5c6-7ef2d10e7747",
       "sourceHandle": "output",
       "target": "1473a6ed-fb5c-4224-8de1-0d2183650122",
@@ -1465,7 +1405,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ab954924-07f4-4c38-ba2e-892503b58017",
       "sourceHandle": "out",
       "target": "1473a6ed-fb5c-4224-8de1-0d2183650122",
@@ -1476,7 +1415,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "6e7d59f9-6e6d-45c7-8522-435ed3dee36f",
       "sourceHandle": "output",
       "target": "5064c342-b8b6-4a6a-b5c6-7ef2d10e7747",
@@ -1487,7 +1425,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "distance",
       "target": "5064c342-b8b6-4a6a-b5c6-7ef2d10e7747",
@@ -1498,7 +1435,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "8890782e-b3f4-4494-97b6-48b54a1f8267",
       "sourceHandle": "out",
       "target": "6e7d59f9-6e6d-45c7-8522-435ed3dee36f",
@@ -1509,7 +1445,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4da61bf2-e9f5-49c6-b314-ed8fa860d102",
       "sourceHandle": "output",
       "target": "6e7d59f9-6e6d-45c7-8522-435ed3dee36f",
@@ -1520,7 +1455,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "dc9a5b40-c47c-48d1-a29a-8b8b369c3ce3",
       "sourceHandle": "out",
       "target": "4da61bf2-e9f5-49c6-b314-ed8fa860d102",
@@ -1531,7 +1465,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "243e49f9-a558-4a42-8035-ef394b58580a",
       "sourceHandle": "output",
       "target": "4da61bf2-e9f5-49c6-b314-ed8fa860d102",
@@ -1542,7 +1475,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "c67108f0-cfbb-4b54-b46e-14b1da8d0ff8",
       "sourceHandle": "output",
       "target": "243e49f9-a558-4a42-8035-ef394b58580a",
@@ -1553,7 +1485,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "c4d0bea9-8300-483b-911b-7d04651fc227",
       "sourceHandle": "output",
       "target": "243e49f9-a558-4a42-8035-ef394b58580a",
@@ -1564,7 +1495,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "6694c6e4-6aa6-45c2-a442-8c8854e5fdbf",
       "sourceHandle": "out",
       "target": "c4d0bea9-8300-483b-911b-7d04651fc227",
@@ -1575,7 +1505,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "8e3b2c73-91c6-4b7d-bcac-98840f1888bb",
       "sourceHandle": "out",
       "target": "c4d0bea9-8300-483b-911b-7d04651fc227",
@@ -1586,7 +1515,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "d88f9ced-0087-4d22-b68a-f5d0d046b1a1",
       "sourceHandle": "out",
       "target": "c4d0bea9-8300-483b-911b-7d04651fc227",
@@ -1597,7 +1525,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "5609772c-d77c-4932-af7d-426cc02354eb",
       "sourceHandle": "out",
       "target": "c4d0bea9-8300-483b-911b-7d04651fc227",
@@ -1608,7 +1535,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "3025d860-39ca-4d58-89c5-d16a90f607c6",
       "sourceHandle": "output",
       "target": "c67108f0-cfbb-4b54-b46e-14b1da8d0ff8",
@@ -1619,7 +1545,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "a1e33eeb-7498-49ed-879b-a8abf850fb35",
       "sourceHandle": "output",
       "target": "c67108f0-cfbb-4b54-b46e-14b1da8d0ff8",
@@ -1630,7 +1555,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "9ff8424b-bee7-423b-98cc-ba451557b842",
       "sourceHandle": "out",
       "target": "3025d860-39ca-4d58-89c5-d16a90f607c6",
@@ -1641,7 +1565,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "visualAcuity",
       "target": "a1e33eeb-7498-49ed-879b-a8abf850fb35",
@@ -1652,7 +1575,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1",
       "sourceHandle": "lightingCondition",
       "target": "a1e33eeb-7498-49ed-879b-a8abf850fb35",
@@ -1663,7 +1585,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "dae95afc-4ae2-4600-bbbb-a4a04ea43c93",
       "sourceHandle": "out",
       "target": "3025d860-39ca-4d58-89c5-d16a90f607c6",
@@ -1674,7 +1595,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "6a4bf5be-a6af-40be-9472-f63f62abc76c",
       "sourceHandle": "out",
       "target": "3025d860-39ca-4d58-89c5-d16a90f607c6",
@@ -1685,7 +1605,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "0fd0e6f7-2d43-4008-916c-37909eec03f0",
       "sourceHandle": "out",
       "target": "3025d860-39ca-4d58-89c5-d16a90f607c6",

--- a/packages/ui/src/examples/scale.json
+++ b/packages/ui/src/examples/scale.json
@@ -101,7 +101,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "green",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -112,7 +111,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "purple",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -123,7 +121,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "gray",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -134,7 +131,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "c4f21d13-b069-4e2c-8f95-6bbdea22b8d8",
       "sourceHandle": "output",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -145,7 +141,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "neutralgray",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -156,7 +151,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "red",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -167,7 +161,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "blue",
       "target": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
@@ -178,7 +171,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "3259c8c8-a569-4604-aefd-eb1d55d9e9e2",
       "sourceHandle": "output",
       "target": "e5ae4b1f-e8ae-4834-b405-45d8f99ea170",
@@ -189,7 +181,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "red",
       "target": "5d39e157-1191-4030-b542-7c9c88f70a7b",
@@ -200,7 +191,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "e5ae4b1f-e8ae-4834-b405-45d8f99ea170",
       "sourceHandle": "array",
       "target": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
@@ -211,7 +201,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4e2e8601-409d-4402-9220-2283bbd426b6",
       "sourceHandle": "as Set",
       "target": "d5cb416a-1441-4e4a-b518-ed36081c0309",
@@ -222,7 +211,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "10",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -233,7 +221,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "9",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -244,7 +231,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "8",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -255,7 +241,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "7",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -266,7 +251,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "6",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -277,7 +261,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "5",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -288,7 +271,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "4",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -299,7 +281,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "3",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -310,7 +291,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "2",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -321,7 +301,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "1",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -332,7 +311,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "0",
       "target": "4e2e8601-409d-4402-9220-2283bbd426b6",
@@ -343,7 +321,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "aa8f3a39-6cd7-492f-a965-185c286ffb7c",
       "sourceHandle": "output",
       "target": "6b7a3081-c18c-4188-a650-3e33be71fecb",
@@ -354,7 +331,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "fc2f6e0d-033f-4cf1-a4d4-776549777f80",
       "sourceHandle": "output",
       "target": "a6c218b5-7349-4881-a1dc-67a2b79e1412",
@@ -365,7 +341,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "fc2f6e0d-033f-4cf1-a4d4-776549777f80",
       "sourceHandle": "output",
       "target": "992ec622-3bf2-4956-96dd-776fb4421283",
@@ -376,7 +351,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "aa8f3a39-6cd7-492f-a965-185c286ffb7c",
       "sourceHandle": "output",
       "target": "fc2f6e0d-033f-4cf1-a4d4-776549777f80",
@@ -387,7 +361,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "aa8f3a39-6cd7-492f-a965-185c286ffb7c",
       "sourceHandle": "output",
       "target": "2aae0b83-080f-41ea-a5bd-1084965168c1",
@@ -398,7 +371,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "aa8f3a39-6cd7-492f-a965-185c286ffb7c",
       "sourceHandle": "output",
       "target": "2aae0b83-080f-41ea-a5bd-1084965168c1",
@@ -409,7 +381,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1f9565c9-077d-4324-9912-3a920d851f56",
       "sourceHandle": "output",
       "target": "9120224b-48a7-4e5c-9627-acb56d914cf4",
@@ -420,7 +391,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "as Set",
       "target": "1f9565c9-077d-4324-9912-3a920d851f56",
@@ -431,7 +401,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "78bc3411-26de-4a6d-b8be-51b59cbf9213",
       "sourceHandle": "output",
       "target": "36cd4cd5-1458-43c1-9e2d-56ada66d509b",
@@ -442,7 +411,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1f9565c9-077d-4324-9912-3a920d851f56",
       "sourceHandle": "output",
       "target": "78bc3411-26de-4a6d-b8be-51b59cbf9213",
@@ -453,7 +421,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "46300734-4056-4af9-ae0c-cd2c68d318ce",
       "sourceHandle": "as Set",
       "target": "aa8f3a39-6cd7-492f-a965-185c286ffb7c",
@@ -464,7 +431,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "aa8f3a39-6cd7-492f-a965-185c286ffb7c",
@@ -475,7 +441,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "07d06853-119b-4c5f-a39d-eac1caed70a4",
       "sourceHandle": "array",
       "target": "ecf5b1ce-5025-4eac-a07f-13eca32c8c9f",
@@ -486,7 +451,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "03d0c217-3e9a-45df-860d-6b44d39810e5",
       "sourceHandle": "array",
       "target": "ecf5b1ce-5025-4eac-a07f-13eca32c8c9f",
@@ -497,7 +461,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "e5ae4b1f-e8ae-4834-b405-45d8f99ea170",
       "sourceHandle": "array",
       "target": "ecf5b1ce-5025-4eac-a07f-13eca32c8c9f",
@@ -508,7 +471,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "bef50913-9c2d-4daa-8477-16b55d354e07",
       "sourceHandle": "output",
       "target": "457a545f-11d4-499a-a077-76e9619201c1",
@@ -519,7 +481,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "bef50913-9c2d-4daa-8477-16b55d354e07",
@@ -530,7 +491,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "89a04413-c4fe-4dd4-9a63-342bb23dbecb",
@@ -541,7 +501,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "as Set",
       "target": "4de3580c-799f-4a0b-8f60-01c2cc293102",
@@ -552,7 +511,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "829e697c-47a5-4926-8eb0-1df60449d7c8",
       "sourceHandle": "as Set",
       "target": "481754a9-f420-43f2-ad8f-fc9796c06f09",
@@ -563,7 +521,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7acda950-715e-4bf4-829b-0ad65a948e01",
       "sourceHandle": "asArray",
       "target": "829e697c-47a5-4926-8eb0-1df60449d7c8",
@@ -574,7 +531,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7acda950-715e-4bf4-829b-0ad65a948e01",
       "sourceHandle": "asArray",
       "target": "829e697c-47a5-4926-8eb0-1df60449d7c8",
@@ -585,7 +541,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "5d2bb6c0-aefb-4ef8-bcbf-1da44369417c",
       "sourceHandle": "output",
       "target": "6460b120-9634-47cc-8bb1-a9fd5db6545e",
@@ -596,7 +551,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1f9565c9-077d-4324-9912-3a920d851f56",
       "sourceHandle": "output",
       "target": "5d2bb6c0-aefb-4ef8-bcbf-1da44369417c",
@@ -607,7 +561,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "0",
       "target": "4227db0e-42de-4cbf-908b-d9a211a5ade9",
@@ -618,7 +571,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7acda950-715e-4bf4-829b-0ad65a948e01",
       "sourceHandle": "asArray",
       "target": "908fe15b-0403-4627-bc53-a8574d103b6b",
@@ -629,7 +581,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "as Set",
       "target": "b163f694-b00c-40b3-b3ee-0798629c5230",
@@ -640,7 +591,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7acda950-715e-4bf4-829b-0ad65a948e01",
       "sourceHandle": "asArray",
       "target": "b163f694-b00c-40b3-b3ee-0798629c5230",
@@ -651,7 +601,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "1f9565c9-077d-4324-9912-3a920d851f56",
@@ -662,7 +611,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "46300734-4056-4af9-ae0c-cd2c68d318ce",
       "sourceHandle": "as Set",
       "target": "1f9565c9-077d-4324-9912-3a920d851f56",
@@ -673,7 +621,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "1f9565c9-077d-4324-9912-3a920d851f56",
       "sourceHandle": "output",
       "target": "21cc5535-0562-4f5c-b352-b15af9b7d127",
@@ -684,7 +631,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "b0cb9604-bf87-4314-a068-7d6701b9e52f",
       "sourceHandle": "as Set",
       "target": "d2bfdc88-5294-4e93-bec7-1eae502dc5b7",
@@ -695,7 +641,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "d2bfdc88-5294-4e93-bec7-1eae502dc5b7",
@@ -706,7 +651,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "81d6abc2-3fb9-4826-9d12-0db56a285356",
@@ -717,7 +661,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "8e380b34-9fe9-4df6-a8d2-d89b3c127f3f",
       "sourceHandle": "output",
       "target": "2ca4612b-315d-4f99-a897-98961c002f84",
@@ -728,7 +671,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "8e380b34-9fe9-4df6-a8d2-d89b3c127f3f",
       "sourceHandle": "output",
       "target": "d0e8102e-faf3-42fa-9340-a799ed12ba58",
@@ -739,7 +681,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "8e380b34-9fe9-4df6-a8d2-d89b3c127f3f",
@@ -750,7 +691,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "e5ae4b1f-e8ae-4834-b405-45d8f99ea170",
       "sourceHandle": "array",
       "target": "8e380b34-9fe9-4df6-a8d2-d89b3c127f3f",
@@ -761,7 +701,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "54b6dd56-72f7-4a13-a044-2862ae2cbc4c",
       "sourceHandle": "output",
       "target": "7545ce47-b5eb-4565-9cbb-6235d057903c",
@@ -772,7 +711,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "54b6dd56-72f7-4a13-a044-2862ae2cbc4c",
       "sourceHandle": "output",
       "target": "09938aa3-3296-49de-8141-0f68a18fb088",
@@ -783,7 +721,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "e5ae4b1f-e8ae-4834-b405-45d8f99ea170",
       "sourceHandle": "array",
       "target": "54b6dd56-72f7-4a13-a044-2862ae2cbc4c",
@@ -794,7 +731,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "7d7bef64-de9b-4f4e-b0e2-1098c555697d",
       "sourceHandle": "output",
       "target": "518b6418-2b4c-4813-b6e1-1b65cb48f319",
@@ -805,7 +741,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "7d7bef64-de9b-4f4e-b0e2-1098c555697d",
@@ -816,7 +751,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "5f420518-d1ef-4ed2-a9a7-3ee0ee0c891c",
       "sourceHandle": "output",
       "target": "43ffd3a7-114c-4e37-b5d1-464ae11b7626",
@@ -827,7 +761,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4b1bff1f-618e-4735-8e2c-49ea3ecffdd0",
       "sourceHandle": "asArray",
       "target": "5f420518-d1ef-4ed2-a9a7-3ee0ee0c891c",
@@ -838,7 +771,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "5f420518-d1ef-4ed2-a9a7-3ee0ee0c891c",
@@ -849,7 +781,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4b1bff1f-618e-4735-8e2c-49ea3ecffdd0",
       "sourceHandle": "asArray",
       "target": "d245cf72-7c5c-41b1-9655-78747a893ae8",
@@ -860,7 +791,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "4b1bff1f-618e-4735-8e2c-49ea3ecffdd0",
       "sourceHandle": "asArray",
       "target": "d13b81b5-257e-43cf-8bde-77273d519c89",
@@ -871,7 +801,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
       "sourceHandle": "as Set",
       "target": "d13b81b5-257e-43cf-8bde-77273d519c89",
@@ -882,7 +811,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "03d0c217-3e9a-45df-860d-6b44d39810e5",
       "sourceHandle": "array",
       "target": "ecf74599-8f4c-4263-bcb2-8c207f4a3322",
@@ -893,7 +821,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "red",
       "target": "03d0c217-3e9a-45df-860d-6b44d39810e5",
@@ -904,7 +831,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "07d06853-119b-4c5f-a39d-eac1caed70a4",
       "sourceHandle": "array",
       "target": "46300734-4056-4af9-ae0c-cd2c68d318ce",
@@ -915,7 +841,6 @@
     },
     {
       "style": { "strokeWidth": 2 },
-      "markerEnd": { "type": "arrowclosed" },
       "source": "00c390d9-adcd-4c85-932c-a17835dab0b9",
       "sourceHandle": "blue",
       "target": "07d06853-119b-4c5f-a39d-eac1caed70a4",


### PR DESCRIPTION
Changes the markerEnd property to not use arrow heads and instead favor the simpler default of no arrow heads.

Also removes this property from any tests.