### PR TITLE
Clean up default preview

### DIFF
--- a/.changeset/wicked-ladybugs-fetch.md
+++ b/.changeset/wicked-ladybugs-fetch.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-engine-ui": patch
+---
+
+Changes preview to be a helpful getting started guide

--- a/packages/ui/src/components/preview/index.tsx
+++ b/packages/ui/src/components/preview/index.tsx
@@ -10,8 +10,7 @@ export const Preview = () => {
   const output = useSelector(outputSelector);
 
   return (
-    // Note we are explicitly setting the font-family to 'initial' here because otherwise the value might leak into the preview from a higher level
-    <div id="preview" style={{ fontFamily: 'initial' }}>
+    <div id="preview">
       <OutputProvider value={output}>
         <TokenContextProvider context={output}>
           <Box css={{ padding: '$5', overflow: 'hidden' }}>

--- a/packages/ui/src/components/preview/scope.tsx
+++ b/packages/ui/src/components/preview/scope.tsx
@@ -34,23 +34,16 @@ export const scope = {
 };
 
 export const code = `const Example = () => {
+    /* The parameter inside useTokens maps to the name of your Output node parameters. The CSS Map node lets you connect to any css property, but you can also just pass in any other output, for example a string or a color value. */
+    const cardCSSMap = useTokens('card');
+    const titleCSSMap= useTokens('title');
+    const textCSSMap= useTokens('text');
 
-    const cardStyle = useTokens('container');
-    const cardImageStyle = useTokens('image');
-    const cardContent= useTokens('content');
-    const cardTitle= useTokens('title');
-
-
-    return (<div class="card" style={cardStyle}>
-            <img src="https://images.unsplash.com/photo-1684395521046-fe664a85a9e2?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxlZGl0b3JpYWwtZmVlZHw3fHx8ZW58MHx8fHx8&auto=format&fit=crop&w=500&q=60" alt="Card Image" style={cardImageStyle} />
-            <div style={cardContent}>
-                <h2 style={cardTitle}>Card Title</h2>
-                <p >This is a sample card description.</p>
-                {/* This is a web component provided by lion but wrapped in a token provider. Use'scope=<NAME>' to change the listed scope from  its default 'Button'  */}
-                <wc-button>Read More</wc-button>
-            </div>
+    return (<div style={cardCSSMap}>
+              <h2 style={titleCSSMap}>Dynamic preview</h2>
+              <p style={textCSSMap}>Create an Output node and connect the code in this example to it by using the useTokens hook and see the preview change in real time. Change the code used for this preview to customize it to your liking. This is saved when you save your .json</p>
         </div>);
 }
-render(<Example/>)
 
+render(<Example/>)
 `;

--- a/packages/ui/src/pages/styles.css
+++ b/packages/ui/src/pages/styles.css
@@ -95,3 +95,12 @@ td,
   .dock-panel.dock-style-main .dock-bar{
     border-bottom-color: var(--colors-borderDefault);
   }
+
+/* Reset any browser-based margins for the preview */
+#preview {
+  all: unset;
+
+  h1, h2, h3, h4, h5, h6, p {
+    margin: unset;
+  }
+}


### PR DESCRIPTION
Cleans up the default preview by removing the image, changing the example code to rather be an instruction into how to use this, rather than expecting the user to understand how to use this structure.

This example is still heavily tied to CSS Map, which I think is only a fraction of what the graph will be used for. 

I think this is fine, as the previews will be driven by the examples that users load. However, when starting from scratch, we use this one. I think in the future we might want to let the user "Load a preview" or perhaps even detect based on the `Output` what kind of preview would be valuable (e.g. if I pass in an array of colors, it could be a color scale). -> Probably makes sense to let the user pick eventually from a range of preview examples

<img width="525" alt="CleanShot 2023-10-07 at 11 11 19@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/5bd4f9ec-2788-4f62-9bb3-76f699493fc0">
<img width="491" alt="CleanShot 2023-10-07 at 11 11 26@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/1f54ef0d-25c8-416d-9d11-af83ec33c725">
