### PR TITLE
Move settings to menu

### DIFF
--- a/.changeset/strong-zoos-begin.md
+++ b/.changeset/strong-zoos-begin.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Moves Settings to the left menu

--- a/packages/graph-editor/src/components/Settings.tsx
+++ b/packages/graph-editor/src/components/Settings.tsx
@@ -18,8 +18,7 @@ import {
 } from '#/redux/selectors/settings';
 import { useDispatch } from '#/hooks/useDispatch.ts';
 import { EdgeType, LayoutType } from '#/redux/models/settings.ts';
-import { InformationIcon } from '@iconicicons/react';
-import { GearIcon } from '@radix-ui/react-icons';
+import { InformationIcon, SettingsIcon } from '@iconicicons/react';
 
 const EdgeValues = Object.values(EdgeType);
 const LayoutValues = Object.values(LayoutType);
@@ -39,7 +38,7 @@ export const Settings = () => {
       <Dialog.Trigger asChild>
         <IconButton
           css={{ flexShrink: 0 }}
-          icon={<GearIcon />}
+          icon={<SettingsIcon />}
           variant="invisible"
           tooltip="Settings"
         />

--- a/packages/graph-editor/src/components/flow/controls.tsx
+++ b/packages/graph-editor/src/components/flow/controls.tsx
@@ -43,10 +43,6 @@ export const MiniMapStyled = styled(MiniMap, {
 
 export const CustomControls = (props: ControlProps) => {
   return (
-    <ControlsStyled showInteractive={false} {...props}>
-      <ControlButton>
-        <Settings />
-      </ControlButton>
-    </ControlsStyled>
+    <ControlsStyled showInteractive={false} {...props} />
   );
 };

--- a/packages/graph-editor/src/components/flow/controls.tsx
+++ b/packages/graph-editor/src/components/flow/controls.tsx
@@ -42,7 +42,5 @@ export const MiniMapStyled = styled(MiniMap, {
 });
 
 export const CustomControls = (props: ControlProps) => {
-  return (
-    <ControlsStyled showInteractive={false} {...props} />
-  );
+  return <ControlsStyled showInteractive={false} {...props} />;
 };

--- a/packages/graph-editor/src/editor/index.tsx
+++ b/packages/graph-editor/src/editor/index.tsx
@@ -73,6 +73,7 @@ import { AppsIcon } from '#/components/icons/AppsIcon.tsx';
 import { CommandMenu } from '#/components/CommandPalette.tsx';
 import { ExternalLoaderProvider } from '#/context/ExternalLoaderContext.tsx';
 import { defaultPanelItems } from '#/components/flow/DropPanel/PanelItems.tsx';
+import { Settings } from '#/components/Settings.tsx';
 
 const snapGridCoords: SnapGrid = [16, 16];
 const defaultViewport = { x: 0, y: 0, zoom: 1.5 };
@@ -539,6 +540,7 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
                     variant={showNodesPanel ? 'primary' : 'invisible'}
                   />
                   {props.menuContent}
+                  <Settings />
                 </Stack>
                 {showNodesPanel && (
                   <Box


### PR DESCRIPTION
Moves `Settings` to the left menu

<img width="455" alt="CleanShot 2023-10-07 at 11 18 34@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/3c1b3ffe-6db3-4708-be2d-b2ff3230120c">