### PR TITLE
Adjust error styles

### DIFF
--- a/.changeset/dirty-houses-eat.md
+++ b/.changeset/dirty-houses-eat.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Adjusts error styling for nodes

--- a/packages/graph-editor/src/components/flow/wrapper/node.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/node.tsx
@@ -187,7 +187,7 @@ export const Node = (props: NodeProps) => {
         minWidth: '300px',
         position: 'relative',
         borderRadius: '$medium',
-        background: error ? '$dangerBg' : '$bgDefault',
+        background: '$bgDefault',
       }}
     >
       <NodeToolbar className="nodrag">
@@ -243,6 +243,7 @@ export const Node = (props: NodeProps) => {
               <>
                 <Stack
                   direction="row"
+                  className={error ? 'error' : ''}
                   justify="between"
                   align="center"
                   css={{

--- a/packages/graph-editor/src/components/flow/wrapper/node.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/node.tsx
@@ -129,6 +129,22 @@ export const Collapser = ({ icon, children, collapsed, showContent }) => {
   );
 };
 
+const NodeWrapper = styled('div', {
+  minWidth: '300px',
+  position: 'relative',
+  borderRadius: '$medium',
+  background: '$bgDefault',
+  variants: {
+    error: {
+      true: {
+        '--nodeBorderColor': 'var(--colors-dangerFg)',
+        '--nodeBgColor': 'var(--colors-dangerBg)',
+        '--nodeTextColor': 'var(--colors-dangerFg)',
+      },
+    },
+  },
+});
+
 export const Node = (props: NodeProps) => {
   const { id, icon, title, error, isAsync, children, controls, ...rest } =
     props;
@@ -182,14 +198,7 @@ export const Node = (props: NodeProps) => {
   const onDetach = () => detachNodes([id]);
 
   return (
-    <Box
-      css={{
-        minWidth: '300px',
-        position: 'relative',
-        borderRadius: '$medium',
-        background: '$bgDefault',
-      }}
-    >
+    <NodeWrapper error={Boolean(error)} className={error ? 'error' : ''}>
       <NodeToolbar className="nodrag">
         <Stack
           direction="row"
@@ -243,7 +252,6 @@ export const Node = (props: NodeProps) => {
               <>
                 <Stack
                   direction="row"
-                  className={error ? 'error' : ''}
                   justify="between"
                   align="center"
                   css={{
@@ -315,7 +323,7 @@ export const Node = (props: NodeProps) => {
           </Stack>
         </FocusTrap>
       </HandleContainerContext.Provider>
-    </Box>
+    </NodeWrapper>
   );
 };
 

--- a/packages/graph-editor/src/index.css
+++ b/packages/graph-editor/src/index.css
@@ -23,24 +23,11 @@
     opacity: 0.25;
 }
 
-.react-flow__node.error {
-    --nodeBorderColor: var(--colors-dangerFg);
-    --nodeBgColor: var(--colors-dangerBg);
-    --nodeTextColor: var(--colors-dangerFg);
-}
-
 .react-flow__node.selectable.selected, .react-flow__node.selectable:focus {
     --nodeBorderColor: var(--colors-accentMuted);
     --nodeBgColor: var(--colors-accentBg);
     --nodeTextColor: var(--colors-fgDefault);
     outline: 2px solid var(--colors-accentMuted);
-}
-
-.react-flow__node.selectable.selected.error, .react-flow__node.selectable.error:focus {
-    --nodeBorderColor: var(--colors-dangerBorder);
-    --nodeBgColor: var(--colors-dangerBg);
-    --nodeTextColor: var(--colors-dangerFg);
-    outline: 2px solid var(--colors-dangerBorder);
 }
 
 .react-flow__edge.selected .react-flow__edge-path, .react-flow__edge:focus .react-flow__edge-path, .react-flow__edge:focus-visible .react-flow__edge-path {

--- a/packages/graph-editor/src/index.css
+++ b/packages/graph-editor/src/index.css
@@ -23,11 +23,24 @@
     opacity: 0.25;
 }
 
+.react-flow__node.error {
+    --nodeBorderColor: var(--colors-dangerFg);
+    --nodeBgColor: var(--colors-dangerBg);
+    --nodeTextColor: var(--colors-dangerFg);
+}
+
 .react-flow__node.selectable.selected, .react-flow__node.selectable:focus {
     --nodeBorderColor: var(--colors-accentMuted);
     --nodeBgColor: var(--colors-accentBg);
     --nodeTextColor: var(--colors-fgDefault);
     outline: 2px solid var(--colors-accentMuted);
+}
+
+.react-flow__node.selectable.selected.error, .react-flow__node.selectable.error:focus {
+    --nodeBorderColor: var(--colors-dangerBorder);
+    --nodeBgColor: var(--colors-dangerBg);
+    --nodeTextColor: var(--colors-dangerFg);
+    outline: 2px solid var(--colors-dangerBorder);
 }
 
 .react-flow__edge.selected .react-flow__edge-path, .react-flow__edge:focus .react-flow__edge-path, .react-flow__edge:focus-visible .react-flow__edge-path {


### PR DESCRIPTION
Slightly adjusts error styles to be more visual

Screenshots show selected and unselected state

<img width="604" alt="CleanShot 2023-10-08 at 11 50 29@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/837ddaaf-70a1-4f8a-adc5-5dfd167c9660">


<img width="603" alt="CleanShot 2023-10-08 at 11 50 47@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/b1c52e88-21fc-4f98-9c46-abb0f4e3622d">
