### PR TITLE
Basic sidesheet (WIP)

### DIFF
--- a/packages/graph-editor/src/components/flow/handles.tsx
+++ b/packages/graph-editor/src/components/flow/handles.tsx
@@ -29,7 +29,12 @@ export const HandleContainerContext = createContext<{
   hide: false,
 });
 
-export const HandleContainer = ({ type, children, shouldHide = false, full }: HolderProps) => {
+export const HandleContainer = ({
+  type,
+  children,
+  shouldHide = false,
+  full,
+}: HolderProps) => {
   if (shouldHide) return null;
   const position = type === 'source' ? Position.Right : Position.Left;
   return (
@@ -97,8 +102,8 @@ const StyledRawHandle = styled(RawHandle, {
     shouldHideHandles: {
       true: {
         display: 'none',
-      }
-    }
+      },
+    },
   },
   '&:hover': {
     '&::after': {
@@ -185,7 +190,11 @@ export const Handle = (props) => {
         gap={2}
         justify={full ? 'between' : type === 'target' ? 'start' : 'end'}
         align="center"
-        css={{ flex: 1, paddingLeft: shouldHideHandles ? 0 : '$3', paddingRight: shouldHideHandles ? 0: '$3' }}
+        css={{
+          flex: 1,
+          paddingLeft: shouldHideHandles ? 0 : '$3',
+          paddingRight: shouldHideHandles ? 0 : '$3',
+        }}
       >
         {children}
       </Stack>

--- a/packages/graph-editor/src/components/flow/handles.tsx
+++ b/packages/graph-editor/src/components/flow/handles.tsx
@@ -16,6 +16,7 @@ export const HandleContext = createContext<{
 type HolderProps = {
   type: 'source' | 'target';
   children: React.ReactNode;
+  shouldHide?: boolean;
   full?: boolean;
 };
 
@@ -28,7 +29,8 @@ export const HandleContainerContext = createContext<{
   hide: false,
 });
 
-export const HandleContainer = ({ type, children, full }: HolderProps) => {
+export const HandleContainer = ({ type, children, shouldHide = false, full }: HolderProps) => {
+  if (shouldHide) return null;
   const position = type === 'source' ? Position.Right : Position.Left;
   return (
     <HandleContext.Provider value={{ type, position }}>
@@ -92,6 +94,11 @@ const StyledRawHandle = styled(RawHandle, {
         marginRight: '4px',
       },
     },
+    shouldHideHandles: {
+      true: {
+        display: 'none',
+      }
+    }
   },
   '&:hover': {
     '&::after': {
@@ -153,7 +160,7 @@ const HandleHolder = styled(Box, {
 });
 
 export const Handle = (props) => {
-  const { children, error, full, ...rest } = props;
+  const { children, shouldHideHandles = false, error, full, ...rest } = props;
   const { position, type } = useHandle();
   const isValidConnection = useIsValidConnection();
   const { collapsed, hide } = useContext(HandleContainerContext);
@@ -162,6 +169,7 @@ export const Handle = (props) => {
   return (
     <HandleHolder collapsed={collapsed}>
       <StyledRawHandle
+        shouldHideHandles={shouldHideHandles}
         error={error}
         left={type === 'target'}
         isConnected={isValidConnection}
@@ -177,7 +185,7 @@ export const Handle = (props) => {
         gap={2}
         justify={full ? 'between' : type === 'target' ? 'start' : 'end'}
         align="center"
-        css={{ flex: 1, paddingLeft: '$3', paddingRight: '$3' }}
+        css={{ flex: 1, paddingLeft: shouldHideHandles ? 0 : '$3', paddingRight: shouldHideHandles ? 0: '$3' }}
       >
         {children}
       </Stack>

--- a/packages/graph-editor/src/components/flow/nodes/color/scaleNode.tsx
+++ b/packages/graph-editor/src/components/flow/nodes/color/scaleNode.tsx
@@ -13,7 +13,8 @@ import PreviewNumber from '../../preview/number.tsx';
 import React, { useCallback, useMemo } from 'react';
 import { ColorWheelIcon } from '@radix-ui/react-icons';
 
-const ScaleNode = () => {
+// We introduce a isSettings prop to the node so we dont have to build the contents twice. Another way to do this would be to have a separate node for the settings and the node itself. Or.. to understand "where am i rendered" in the node itself, but that would be a bit more complex.
+const ScaleNode = ({isSettings}: {isSettings?: boolean}) => {
   const { input, state, output, setState } = useNode();
 
   const outputHandles = useMemo(() => {
@@ -28,7 +29,7 @@ const ScaleNode = () => {
       })
       .map(([key, value]) => {
         return (
-          <Handle id={key} key={key}>
+          <Handle shouldHideHandles={isSettings} id={key} key={key}>
             <Text
               css={{
                 fontFamily: 'monospace',
@@ -45,7 +46,7 @@ const ScaleNode = () => {
 
     return (
       <>
-        <Handle id="array">
+        <Handle shouldHideHandles={isSettings} id="array">
           <HandleText>Set</HandleText>
           <PreviewArray value={array} />
         </Handle>
@@ -73,35 +74,36 @@ const ScaleNode = () => {
   return (
     <Stack direction="row" gap={4}>
       <HandleContainer type="target">
-        <Handle id="color">
+        <Handle shouldHideHandles={isSettings} id="color">
           <Stack direction="row" justify="between" gap={3} align="center">
             <HandleText>Color</HandleText>
             <PreviewColor value={input.color} />
           </Stack>
         </Handle>
-        <Handle id="stepsUp">
+        <Handle shouldHideHandles={isSettings} id="stepsUp">
           <Stack direction="row" justify="between" gap={3} align="center">
             <HandleText secondary>Steps ↑</HandleText>
-            {input.stepsUp !== undefined ? (
-              <PreviewNumber value={input.stepsUp} />
+            {isSettings ? <>{input.stepsUp !== undefined ? (
+              <PreviewNumber value={input.stepsUp || state.stepsUp} />
             ) : (
               <TextInput onChange={setStepsUp} value={state.stepsUp} />
-            )}
+            )}</> : <DynamicValueText>{input.stepsUp || state.stepsUp}</DynamicValueText>}
           </Stack>
         </Handle>
-        <Handle id="stepsDown">
+        <Handle shouldHideHandles={isSettings} id="stepsDown">
           <Stack direction="row" justify="between" gap={3} align="center">
             <HandleText secondary>Steps ↓</HandleText>
 
-            {input.stepsDown !== undefined ? (
-              <PreviewNumber value={input.stepsDown} />
+            {isSettings ? <>{input.stepsDown !== undefined ? (
+              <PreviewNumber value={input.stepsDown || state.stepsDown} />
             ) : (
               <TextInput onChange={setStepsDown} value={state.stepsDown} />
-            )}
+            )}</> : <DynamicValueText>{input.stepsDown || state.stepsDown}</DynamicValueText>}
           </Stack>
         </Handle>
       </HandleContainer>
-      <HandleContainer type="source">{outputHandles}</HandleContainer>
+      {/* Hide output handles for now. Ideally we'd have a proper way to display outputs here, but I think for now the goal is to get the inputs out of the graph */}
+      <HandleContainer shouldHide={isSettings} type="source">{outputHandles}</HandleContainer>
     </Stack>
   );
 };
@@ -110,4 +112,4 @@ export default WrapNode(ScaleNode, {
   ...node,
   title: 'Generate Color Scale',
   icon: <ColorWheelIcon />,
-});
+}, <ScaleNode isSettings />);

--- a/packages/graph-editor/src/components/flow/nodes/color/scaleNode.tsx
+++ b/packages/graph-editor/src/components/flow/nodes/color/scaleNode.tsx
@@ -14,7 +14,7 @@ import React, { useCallback, useMemo } from 'react';
 import { ColorWheelIcon } from '@radix-ui/react-icons';
 
 // We introduce a isSettings prop to the node so we dont have to build the contents twice. Another way to do this would be to have a separate node for the settings and the node itself. Or.. to understand "where am i rendered" in the node itself, but that would be a bit more complex.
-const ScaleNode = ({isSettings}: {isSettings?: boolean}) => {
+const ScaleNode = ({ isSettings }: { isSettings?: boolean }) => {
   const { input, state, output, setState } = useNode();
 
   const outputHandles = useMemo(() => {
@@ -83,33 +83,55 @@ const ScaleNode = ({isSettings}: {isSettings?: boolean}) => {
         <Handle shouldHideHandles={isSettings} id="stepsUp">
           <Stack direction="row" justify="between" gap={3} align="center">
             <HandleText secondary>Steps ↑</HandleText>
-            {isSettings ? <>{input.stepsUp !== undefined ? (
-              <PreviewNumber value={input.stepsUp || state.stepsUp} />
+            {isSettings ? (
+              <>
+                {input.stepsUp !== undefined ? (
+                  <PreviewNumber value={input.stepsUp || state.stepsUp} />
+                ) : (
+                  <TextInput onChange={setStepsUp} value={state.stepsUp} />
+                )}
+              </>
             ) : (
-              <TextInput onChange={setStepsUp} value={state.stepsUp} />
-            )}</> : <DynamicValueText>{input.stepsUp || state.stepsUp}</DynamicValueText>}
+              <DynamicValueText>
+                {input.stepsUp || state.stepsUp}
+              </DynamicValueText>
+            )}
           </Stack>
         </Handle>
         <Handle shouldHideHandles={isSettings} id="stepsDown">
           <Stack direction="row" justify="between" gap={3} align="center">
             <HandleText secondary>Steps ↓</HandleText>
 
-            {isSettings ? <>{input.stepsDown !== undefined ? (
-              <PreviewNumber value={input.stepsDown || state.stepsDown} />
+            {isSettings ? (
+              <>
+                {input.stepsDown !== undefined ? (
+                  <PreviewNumber value={input.stepsDown || state.stepsDown} />
+                ) : (
+                  <TextInput onChange={setStepsDown} value={state.stepsDown} />
+                )}
+              </>
             ) : (
-              <TextInput onChange={setStepsDown} value={state.stepsDown} />
-            )}</> : <DynamicValueText>{input.stepsDown || state.stepsDown}</DynamicValueText>}
+              <DynamicValueText>
+                {input.stepsDown || state.stepsDown}
+              </DynamicValueText>
+            )}
           </Stack>
         </Handle>
       </HandleContainer>
       {/* Hide output handles for now. Ideally we'd have a proper way to display outputs here, but I think for now the goal is to get the inputs out of the graph */}
-      <HandleContainer shouldHide={isSettings} type="source">{outputHandles}</HandleContainer>
+      <HandleContainer shouldHide={isSettings} type="source">
+        {outputHandles}
+      </HandleContainer>
     </Stack>
   );
 };
 
-export default WrapNode(ScaleNode, {
-  ...node,
-  title: 'Generate Color Scale',
-  icon: <ColorWheelIcon />,
-}, <ScaleNode isSettings />);
+export default WrapNode(
+  ScaleNode,
+  {
+    ...node,
+    title: 'Generate Color Scale',
+    icon: <ColorWheelIcon />,
+  },
+  <ScaleNode isSettings />,
+);

--- a/packages/graph-editor/src/components/flow/wrapper/node.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/node.tsx
@@ -29,6 +29,7 @@ import classNames from 'classnames/dedupe.js';
 import useDetachNodes from '../hooks/useDetachNodes.ts';
 import { useSelector } from 'react-redux';
 import { debugMode, obscureDistance } from '#/redux/selectors/settings.ts';
+import { Sidesheet } from '#/editor/Sidesheet.tsx';
 
 const CollapserContainer = styled('div', {});
 
@@ -190,7 +191,8 @@ export const Node = (props: NodeProps) => {
         background: error ? '$dangerBg' : '$bgDefault',
       }}
     >
-      <NodeToolbar className="nodrag">
+      <NodeToolbar>
+        <Sidesheet title={title}>{children}</Sidesheet>
         <Stack
           direction="row"
           gap={0}

--- a/packages/graph-editor/src/components/flow/wrapper/node.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/node.tsx
@@ -29,7 +29,6 @@ import classNames from 'classnames/dedupe.js';
 import useDetachNodes from '../hooks/useDetachNodes.ts';
 import { useSelector } from 'react-redux';
 import { debugMode, obscureDistance } from '#/redux/selectors/settings.ts';
-import { Sidesheet } from '#/editor/Sidesheet.tsx';
 
 const CollapserContainer = styled('div', {});
 
@@ -192,7 +191,6 @@ export const Node = (props: NodeProps) => {
       }}
     >
       <NodeToolbar>
-        <Sidesheet title={title}>{children}</Sidesheet>
         <Stack
           direction="row"
           gap={0}

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -1,4 +1,4 @@
-import { Edge, useReactFlow } from 'reactflow';
+import { Edge, useReactFlow, NodeToolbar } from 'reactflow';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Node } from './node.tsx';
 import {
@@ -26,6 +26,7 @@ import isPromise from 'is-promise';
 import { useOnOutputChange } from '#/context/OutputContext.tsx';
 import { useExternalLoader } from '#/context/ExternalLoaderContext.tsx';
 import { useExternalData } from '#/context/ExternalDataContext.tsx';
+import { Sidesheet } from '#/editor/Sidesheet.tsx';
 
 export type UiNodeDefinition = {
   //Name of the Node
@@ -95,6 +96,7 @@ export type WrappedNodeDefinition = {
 export const WrapNode = (
   InnerNode,
   nodeDef: UiNodeDefinition,
+  settingsContent?: React.ReactNode,
 ): WrappedNodeDefinition => {
   const WrappedNode = (data) => {
     const { loadSetTokens } = useExternalData();
@@ -378,6 +380,13 @@ export const WrapNode = (
         >
           <ErrorBoundary fallbackRender={() => 'Oops I just accidentally ...'}>
             <InnerNode />
+          </ErrorBoundary>
+          <ErrorBoundary fallbackRender={() => 'Oops I just accidentally ...'}>
+            <NodeToolbar>
+              <Sidesheet title={nodeDef.title}>
+                {settingsContent}
+              </Sidesheet>
+            </NodeToolbar>
           </ErrorBoundary>
         </Wrapped>
       </NodeContext.Provider>

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -383,9 +383,7 @@ export const WrapNode = (
           </ErrorBoundary>
           <ErrorBoundary fallbackRender={() => 'Oops I just accidentally ...'}>
             <NodeToolbar>
-              <Sidesheet title={nodeDef.title}>
-                {settingsContent}
-              </Sidesheet>
+              <Sidesheet title={nodeDef.title}>{settingsContent}</Sidesheet>
             </NodeToolbar>
           </ErrorBoundary>
         </Wrapped>

--- a/packages/graph-editor/src/editor/Sidesheet.tsx
+++ b/packages/graph-editor/src/editor/Sidesheet.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, IconButton, Stack, Heading, Text } from '@tokens-studio/ui';
+import * as Portal from '@radix-ui/react-portal';
+import { CloseIcon } from "@iconicicons/react"
+
+export function Sidesheet({ title, children }) {
+    return (<Portal.Root>
+        <Box css={{ display: 'flex', position: 'fixed', right: 0, top: '30vh', bottom: 0, zIndex: 100 }}>
+            <Box css={{ maxWidth: 'clamp(180px, 40vw, 400px)', backgroundColor: '$bgCanvas', padding: '$6', borderTopLeftRadius: '16px', borderBottomLeftRadius: '16px', boxShadow: '$contextMenu', borderLeft: '1px solid $borderSubtle', borderTop: '1px solid $borderSubtle' }}>
+                <Box css={{ position: 'absolute', right: '$6' }}><IconButton icon={<CloseIcon />} variant="invisible" onClick={() => setIsOpen(false)} /></Box>
+                <Stack direction="column" gap={3}>
+                    <Heading size="large">{title}</Heading>
+                    <Text muted>Add extra configuration here that should be shown on selection of a node. When something is selected, the sidesheet is placed on top of other content.</Text>
+                </Stack>
+                {children}
+            </Box>
+        </Box>
+    </Portal.Root>)
+}

--- a/packages/graph-editor/src/editor/Sidesheet.tsx
+++ b/packages/graph-editor/src/editor/Sidesheet.tsx
@@ -1,31 +1,83 @@
 import React from 'react';
 import { Box, IconButton, Stack, Heading, Text } from '@tokens-studio/ui';
 import * as Portal from '@radix-ui/react-portal';
-import { CloseIcon } from "@iconicicons/react"
+import { CloseIcon } from '@iconicicons/react';
 import { isSideSheetMinimizedSelector } from '#/redux/selectors/ui';
 import { useDispatch, useSelector } from 'react-redux';
 
 export function Sidesheet({ title, children }) {
-    const isMinimized = useSelector(isSideSheetMinimizedSelector)
-    const dispatch = useDispatch();
+  const isMinimized = useSelector(isSideSheetMinimizedSelector);
+  const dispatch = useDispatch();
 
-    const handleToggleMinimized = () => dispatch.ui.setIsSideSheetMinimized(!isMinimized)
+  const handleToggleMinimized = () =>
+    dispatch.ui.setIsSideSheetMinimized(!isMinimized);
 
-    if (isMinimized) {
-        return (<Portal.Root><Box as="button" onClick={handleToggleMinimized} css={{ position: 'fixed', right: 0, bottom: 0, zIndex: 100, backgroundColor: '$bgCanvas', border: '1px solid $borderSubtle', borderRightWidth: 0, borderBottomWidth: 0, borderTopLeftRadius: '$medium', padding: '$3 $4', cursor: 'pointer', fontSize: '$xsmall', fontWeight: '$sansMedium' }}>{title}</Box></Portal.Root>)
-    }
-    return (<Portal.Root>
-        <Box css={{ display: 'flex', position: 'fixed', right: 0, minHeight: '30vh', bottom: 0, zIndex: 100 }}>
-            <Box css={{ maxWidth: 'clamp(180px, 40vw, 400px)', backgroundColor: '$bgCanvas', padding: '$6', borderTopLeftRadius: '16px', boxShadow: '$contextMenu', borderLeft: '1px solid $borderSubtle', borderTop: '1px solid $borderSubtle' }}>
-                <Box css={{ position: 'absolute', right: '$6' }}><IconButton icon={<CloseIcon />} variant="invisible" onClick={handleToggleMinimized} /></Box>
-                <Stack direction="column" gap={4}>
-                    <Stack direction="column" gap={3}>
-                        <Heading size="large">{title}</Heading>
-                        <Text muted>We could add the description here as well.</Text>
-                    </Stack>
-                    {children}
-                </Stack>
-            </Box>
+  if (isMinimized) {
+    return (
+      <Portal.Root>
+        <Box
+          as="button"
+          onClick={handleToggleMinimized}
+          css={{
+            position: 'fixed',
+            right: 0,
+            bottom: 0,
+            zIndex: 100,
+            backgroundColor: '$bgCanvas',
+            border: '1px solid $borderSubtle',
+            borderRightWidth: 0,
+            borderBottomWidth: 0,
+            borderTopLeftRadius: '$medium',
+            padding: '$3 $4',
+            cursor: 'pointer',
+            fontSize: '$xsmall',
+            fontWeight: '$sansMedium',
+          }}
+        >
+          {title}
         </Box>
-    </Portal.Root>)
+      </Portal.Root>
+    );
+  }
+  return (
+    <Portal.Root>
+      <Box
+        css={{
+          display: 'flex',
+          position: 'fixed',
+          right: 0,
+          minHeight: '30vh',
+          bottom: 0,
+          zIndex: 100,
+        }}
+      >
+        <Box
+          css={{
+            maxWidth: 'clamp(180px, 40vw, 400px)',
+            backgroundColor: '$bgCanvas',
+            padding: '$6',
+            borderTopLeftRadius: '16px',
+            boxShadow: '$contextMenu',
+            borderLeft: '1px solid $borderSubtle',
+            borderTop: '1px solid $borderSubtle',
+          }}
+        >
+          <Box css={{ position: 'absolute', right: '$6' }}>
+            <IconButton
+              icon={<CloseIcon />}
+              variant="invisible"
+              onClick={handleToggleMinimized}
+            />
+          </Box>
+          <Stack direction="column" gap={4}>
+            <Stack direction="column" gap={3}>
+              <Heading size="large">{title}</Heading>
+              <Text muted>We could add the description here as well.</Text>
+            </Stack>
+            {children}
+          </Stack>
+        </Box>
+      </Box>
+    </Portal.Root>
+  );
 }

--- a/packages/graph-editor/src/editor/Sidesheet.tsx
+++ b/packages/graph-editor/src/editor/Sidesheet.tsx
@@ -20,14 +20,13 @@ export function Sidesheet({ title, children }) {
           onClick={handleToggleMinimized}
           css={{
             position: 'fixed',
-            right: 0,
-            bottom: 0,
-            zIndex: 100,
+            right: '$3',
+            bottom: '$3',
             backgroundColor: '$bgCanvas',
             border: '1px solid $borderSubtle',
             borderRightWidth: 0,
             borderBottomWidth: 0,
-            borderTopLeftRadius: '$medium',
+            borderRadius: '$medium',
             padding: '$3 $4',
             cursor: 'pointer',
             fontSize: '$xsmall',
@@ -45,33 +44,31 @@ export function Sidesheet({ title, children }) {
         css={{
           display: 'flex',
           position: 'fixed',
-          right: 0,
-          minHeight: '30vh',
-          bottom: 0,
-          zIndex: 100,
+          right: '$3',
+          bottom: '$3',
         }}
       >
         <Box
           css={{
             maxWidth: 'clamp(180px, 40vw, 400px)',
-            backgroundColor: '$bgCanvas',
+            backgroundColor: '$bgDefault',
             padding: '$6',
-            borderTopLeftRadius: '16px',
+            paddingTop: '$5',
+            borderRadius: '$medium',
             boxShadow: '$contextMenu',
-            borderLeft: '1px solid $borderSubtle',
-            borderTop: '1px solid $borderSubtle',
+            border: '1px solid $borderSubtle',
           }}
         >
-          <Box css={{ position: 'absolute', right: '$6' }}>
-            <IconButton
-              icon={<CloseIcon />}
-              variant="invisible"
-              onClick={handleToggleMinimized}
-            />
-          </Box>
           <Stack direction="column" gap={4}>
             <Stack direction="column" gap={3}>
-              <Heading size="large">{title}</Heading>
+              <Stack gap={2} align="start" justify="between">
+                <Heading size="large">{title}</Heading>
+                <IconButton
+                  icon={<CloseIcon />}
+                  variant="invisible"
+                  onClick={handleToggleMinimized}
+                />
+              </Stack>
               <Text muted>We could add the description here as well.</Text>
             </Stack>
             {children}

--- a/packages/graph-editor/src/editor/Sidesheet.tsx
+++ b/packages/graph-editor/src/editor/Sidesheet.tsx
@@ -2,17 +2,29 @@ import React from 'react';
 import { Box, IconButton, Stack, Heading, Text } from '@tokens-studio/ui';
 import * as Portal from '@radix-ui/react-portal';
 import { CloseIcon } from "@iconicicons/react"
+import { isSideSheetMinimizedSelector } from '#/redux/selectors/ui';
+import { useDispatch, useSelector } from 'react-redux';
 
 export function Sidesheet({ title, children }) {
+    const isMinimized = useSelector(isSideSheetMinimizedSelector)
+    const dispatch = useDispatch();
+
+    const handleToggleMinimized = () => dispatch.ui.setIsSideSheetMinimized(!isMinimized)
+
+    if (isMinimized) {
+        return (<Portal.Root><Box as="button" onClick={handleToggleMinimized} css={{ position: 'fixed', right: 0, bottom: 0, zIndex: 100, backgroundColor: '$bgCanvas', border: '1px solid $borderSubtle', borderRightWidth: 0, borderBottomWidth: 0, borderTopLeftRadius: '$medium', padding: '$3 $4', cursor: 'pointer', fontSize: '$xsmall', fontWeight: '$sansMedium' }}>{title}</Box></Portal.Root>)
+    }
     return (<Portal.Root>
-        <Box css={{ display: 'flex', position: 'fixed', right: 0, top: '30vh', bottom: 0, zIndex: 100 }}>
-            <Box css={{ maxWidth: 'clamp(180px, 40vw, 400px)', backgroundColor: '$bgCanvas', padding: '$6', borderTopLeftRadius: '16px', borderBottomLeftRadius: '16px', boxShadow: '$contextMenu', borderLeft: '1px solid $borderSubtle', borderTop: '1px solid $borderSubtle' }}>
-                <Box css={{ position: 'absolute', right: '$6' }}><IconButton icon={<CloseIcon />} variant="invisible" onClick={() => setIsOpen(false)} /></Box>
-                <Stack direction="column" gap={3}>
-                    <Heading size="large">{title}</Heading>
-                    <Text muted>Add extra configuration here that should be shown on selection of a node. When something is selected, the sidesheet is placed on top of other content.</Text>
+        <Box css={{ display: 'flex', position: 'fixed', right: 0, minHeight: '30vh', bottom: 0, zIndex: 100 }}>
+            <Box css={{ maxWidth: 'clamp(180px, 40vw, 400px)', backgroundColor: '$bgCanvas', padding: '$6', borderTopLeftRadius: '16px', boxShadow: '$contextMenu', borderLeft: '1px solid $borderSubtle', borderTop: '1px solid $borderSubtle' }}>
+                <Box css={{ position: 'absolute', right: '$6' }}><IconButton icon={<CloseIcon />} variant="invisible" onClick={handleToggleMinimized} /></Box>
+                <Stack direction="column" gap={4}>
+                    <Stack direction="column" gap={3}>
+                        <Heading size="large">{title}</Heading>
+                        <Text muted>We could add the description here as well.</Text>
+                    </Stack>
+                    {children}
                 </Stack>
-                {children}
             </Box>
         </Box>
     </Portal.Root>)

--- a/packages/graph-editor/src/editor/index.tsx
+++ b/packages/graph-editor/src/editor/index.tsx
@@ -575,7 +575,7 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
                 onConnect={onConnect}
                 onDrop={onDrop}
                 onConnectEnd={onConnectEnd}
-                selectNodesOnDrag={false}
+                selectNodesOnDrag={true}
                 defaultEdgeOptions={defaultEdgeOptions}
                 panOnScroll={true}
                 //Note that we cannot use pan on drag or it will affect the context menu

--- a/packages/graph-editor/src/redux/models/ui.ts
+++ b/packages/graph-editor/src/redux/models/ui.ts
@@ -5,6 +5,7 @@ export interface UIState {
   showNodesPanel: boolean;
   showNodesCmdPalette: boolean;
   storeNodeInsertPosition: { x: number; y: number };
+  isSideSheetMinimized: boolean;
 }
 
 export const uiState = createModel<RootModel>()({
@@ -12,6 +13,7 @@ export const uiState = createModel<RootModel>()({
     showNodesPanel: true,
     showNodesCmdPalette: false,
     storeNodeInsertPosition: { x: 0, y: 0 },
+    isSideSheetMinimized: false,
   } as UIState,
   reducers: {
     setShowNodesPanel(state, showNodesPanel: boolean) {
@@ -32,5 +34,11 @@ export const uiState = createModel<RootModel>()({
         storeNodeInsertPosition: nodeInsertPosition,
       };
     },
+    setIsSideSheetMinimized(state, isSideSheetMinimized: boolean) {
+      return {
+        ...state,
+        isSideSheetMinimized,
+      };
+    }
   },
 });

--- a/packages/graph-editor/src/redux/models/ui.ts
+++ b/packages/graph-editor/src/redux/models/ui.ts
@@ -39,6 +39,6 @@ export const uiState = createModel<RootModel>()({
         ...state,
         isSideSheetMinimized,
       };
-    }
+    },
   },
 });

--- a/packages/graph-editor/src/redux/selectors/ui.ts
+++ b/packages/graph-editor/src/redux/selectors/ui.ts
@@ -15,3 +15,8 @@ export const storeNodeInsertPositionSelector = createSelector(
   ui,
   (state) => state.storeNodeInsertPosition,
 );
+
+export const isSideSheetMinimizedSelector = createSelector(
+  ui,
+  (state) => state.isSideSheetMinimized,
+);


### PR DESCRIPTION
Closes https://github.com/tokens-studio/graph-engine/issues/75

This PR adds support for a Sidesheet for nodes. By default we display the node title (and we could also display descriptions once we have them from #115)

Then, each node can define via `isSettings` if certain props should be displayed, or how they should be displayed (e.g. Inputs in the Sidesheet, previews on the node).

Eventually we could let users control via node settings which settings they want to expose vs. which they just want in the sidesheet (should save it on each node prob?). For now, this is laying the foundation to that.

We should change _all_ nodes to configure what is displayed where.

This PR just shows how it can be done in the `scaleNode` node. (see bottom how WrapNode is changed and how the handles are hidden using `isSettings`.

https://github.com/tokens-studio/graph-engine/assets/4548309/31fd22d9-12ca-46fe-98d7-66d629f75b46



