### PR TITLE
Fix Docs URL

### DIFF
--- a/packages/documentation/theme.config.js
+++ b/packages/documentation/theme.config.js
@@ -2,7 +2,7 @@
 import { useRouter } from "next/router";
 
 
-const GITHUB_LINK = 'https://github.com/tokens-studio/graph-engine-docs';
+const GITHUB_LINK = 'https://github.com/tokens-studio/graph-engine/packages/documentation';
 const TITLE = 'Graph engine documentation'
 
 const Slack = () => (


### PR DESCRIPTION
fixes the Docs URL that we were using in the GitHub links in the graph docs