### PR TITLE
Adjust default menu and make controllable

### DIFF
--- a/.changeset/wicked-geese-call.md
+++ b/.changeset/wicked-geese-call.md
@@ -1,0 +1,7 @@
+---
+"@tokens-studio/graph-editor": patch
+"@tokens-studio/graph-engine-ui": patch
+---
+
+Added new props to the editor: `showNodesPanel` and `onShowNodesPanelChange` to make appearance of nodes panel optional and controllable.
+Fixed vertical scroll of nodes panel

--- a/packages/graph-editor/src/components/flow/DropPanel/DropPanel.tsx
+++ b/packages/graph-editor/src/components/flow/DropPanel/DropPanel.tsx
@@ -92,86 +92,84 @@ export const DropPanel = React.forwardRef<ImperativeDropPanelRef, IDropPanel>(
         }}
         id="drop-panel"
       >
-        <Scroll height="100%">
+        <Stack
+          direction="column"
+          gap={3}
+          css={{ paddingTop: '$1', width: '100%' }}
+        >
           <Stack
             direction="column"
-            gap={3}
-            css={{ paddingTop: '$1', width: '100%' }}
+            gap={2}
+            css={{ padding: '0 $5', paddingTop: '$4' }}
           >
-            <Stack
-              direction="column"
-              gap={2}
-              css={{ padding: '0 $5', paddingTop: '$4' }}
+            <Text
+              css={{
+                fontSize: '$xxsmall',
+                fontWeight: '$sansMedium',
+                textTransform: 'uppercase',
+                letterSpacing: '0.15px',
+              }}
             >
-              <Text
-                css={{
-                  fontSize: '$xxsmall',
-                  fontWeight: '$sansMedium',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.15px',
-                }}
-              >
-                Nodes
-              </Text>
-              <TextInput
-                placeholder="Search…"
-                value={search}
-                onChange={onSearch}
-              />
-            </Stack>
-            <StyledAccordion type="multiple" defaultValue={defaultValue}>
-              {items.map((value) => {
-                const filteredValues = value.items
-                  .filter((item) =>
-                    item.text.toLowerCase().includes(search.toLowerCase()),
-                  )
-                  .map((item) => (
-                    <DragItem
-                      type={item.type}
-                      data={item.data || null}
-                      key={item.text}
-                      docs={item.docs}
-                      description={item.description}
-                      title={item.text}
-                      icon={item.icon}
-                    >
-                      <NodeEntry icon={item.icon} text={item.text} />
-                    </DragItem>
-                  ));
-
-                return (
-                  <Accordion.Item value={value.key} key={value.key}>
-                    <StyledAccordionTrigger>
-                      <Box
-                        css={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          color: '$fgSubtle',
-                          width: '24px',
-                          height: '24px',
-                        }}
-                      >
-                        <StyledChevron />
-                      </Box>
-                      <Text size="xsmall" bold>
-                        {value.title}
-                      </Text>
-                    </StyledAccordionTrigger>
-                    <Accordion.Content>
-                      <Stack
-                        direction="column"
-                        css={{ padding: 0, marginBottom: '$4' }}
-                      >
-                        {filteredValues}
-                      </Stack>
-                    </Accordion.Content>
-                  </Accordion.Item>
-                );
-              })}
-            </StyledAccordion>
+              Nodes
+            </Text>
+            <TextInput
+              placeholder="Search…"
+              value={search}
+              onChange={onSearch}
+            />
           </Stack>
-        </Scroll>
+          <StyledAccordion type="multiple" defaultValue={defaultValue}>
+            {items.map((value) => {
+              const filteredValues = value.items
+                .filter((item) =>
+                  item.text.toLowerCase().includes(search.toLowerCase()),
+                )
+                .map((item) => (
+                  <DragItem
+                    type={item.type}
+                    data={item.data || null}
+                    key={item.text}
+                    docs={item.docs}
+                    description={item.description}
+                    title={item.text}
+                    icon={item.icon}
+                  >
+                    <NodeEntry icon={item.icon} text={item.text} />
+                  </DragItem>
+                ));
+
+              return (
+                <Accordion.Item value={value.key} key={value.key}>
+                  <StyledAccordionTrigger>
+                    <Box
+                      css={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: '$fgSubtle',
+                        width: '24px',
+                        height: '24px',
+                      }}
+                    >
+                      <StyledChevron />
+                    </Box>
+                    <Text size="xsmall" bold>
+                      {value.title}
+                    </Text>
+                  </StyledAccordionTrigger>
+                  <Accordion.Content>
+                    <Stack
+                      direction="column"
+                      css={{ padding: 0, marginBottom: '$4' }}
+                    >
+                      {filteredValues}
+                    </Stack>
+                  </Accordion.Content>
+                </Accordion.Item>
+              );
+            })}
+          </StyledAccordion>
+        </Stack>
       </Box>
     );
   },

--- a/packages/graph-editor/src/editor/editorTypes.ts
+++ b/packages/graph-editor/src/editor/editorTypes.ts
@@ -31,6 +31,14 @@ export interface EditorProps {
    * Whether or not to show the menu
    */
   showMenu?: boolean;
+  /**
+   * Whether or not to show the nodes panel
+   */
+  shouldShowNodesPanel?: boolean;
+  /**
+   * Callback to be called when the nodes panel is shown or hidden
+   */
+  onShowNodesPanelChange?: (show: boolean) => void;
 }
 
 export type EditorState = {

--- a/packages/graph-editor/src/editor/index.tsx
+++ b/packages/graph-editor/src/editor/index.tsx
@@ -61,7 +61,6 @@ import { showGrid, snapGrid } from '#/redux/selectors/settings.ts';
 import { showNodesPanelSelector } from '#/redux/selectors/ui.ts';
 import { forceUpdate } from '#/redux/selectors/graph.ts';
 import { DropPanel } from '#/components/index.ts';
-import { AppsIcon } from '#/components/icons/AppsIcon.tsx';
 import { CommandMenu } from '#/components/CommandPalette.tsx';
 import { ExternalLoaderProvider } from '#/context/ExternalLoaderContext.tsx';
 import { defaultPanelItems } from '#/components/flow/DropPanel/PanelItems.tsx';
@@ -107,9 +106,15 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
     const showNodesPanel = useSelector(showNodesPanelSelector);
     const forceUpdateValue = useSelector(forceUpdate);
 
-    const handleTogglePanel = () => {
-      dispatch.ui.setShowNodesPanel(!showNodesPanel);
-    };
+    React.useEffect(() => {
+      if (!!props.shouldShowNodesPanel) dispatch.ui.setShowNodesPanel(props.shouldShowNodesPanel);
+    }, [props.shouldShowNodesPanel]);
+
+    React.useEffect(() => {
+      if (typeof props.onShowNodesPanelChange === 'function') {
+        props.onShowNodesPanelChange(showNodesPanel);
+      }
+    }, [showNodesPanel]);
 
     const [contextNode, setContextNode] = React.useState<Node | null>(null);
     const [contextEdge, setContextEdge] = React.useState<Edge | null>(null);
@@ -514,44 +519,42 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
             }}
           >
             <ForceUpdateProvider value={forceUpdate}>
-              <Box css={{ display: 'flex', flexDirection: 'row', zIndex: 0 }}>
+              <Box css={{ position: 'absolute', zIndex: 500, display: 'flex', flexDirection: 'row', height: '100%' }}>
                 {showMenu && (
                   <Stack
                     direction="column"
                     gap={2}
                     css={{
                       position: 'relative',
-                      backgroundColor: '$bgDefault',
-                      padding: '$1',
-                      borderRight: '1px solid $borderSubtle',
+                      padding: '$3',
+                      paddingRight: 0,
+                      zIndex: 600,
                     }}
                   >
-                    <IconButton
-                      tooltip="Add nodes (n)"
-                      onClick={handleTogglePanel}
-                      icon={<AppsIcon />}
-                      variant={showNodesPanel ? 'primary' : 'invisible'}
-                    />
                     {props.menuContent}
                     <Settings />
                   </Stack>
                 )}
                 {showNodesPanel && (
-                  <Box
-                    css={{
-                      backgroundColor: '$bgDefault',
-                      width: '240px',
-                      overflow: 'hidden',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      borderRight: '1px solid $borderMuted',
-                    }}
-                  >
-                    <DropPanel groups={[]} items={panelItems} />
+                  <Box css={{paddingLeft: '$3', paddingTop: '$3', paddingBottom: '$3'}}>
+                    <Box
+                      css={{
+                        backgroundColor: '$bgDefault',
+                        width: 'var(--globals-drop-panel-width)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        border: '1px solid $borderSubtle',
+                        boxShadow: '$small',
+                        borderRadius: '$medium',
+                        overflowY: 'auto',
+                        maxHeight: '100%'
+                      }}
+                    >
+                      <DropPanel groups={[]} items={panelItems} />
+                    </Box>
                   </Box>
                 )}
               </Box>
-              {/* @ts-ignore */}
               <ReactFlow
                 ref={reactFlowWrapper}
                 fitView

--- a/packages/graph-editor/src/index.css
+++ b/packages/graph-editor/src/index.css
@@ -1,5 +1,10 @@
 @import url('reactflow/dist/style.css');
 @import url('react-contexify/ReactContexify.css');
+
+:root {
+    --globals-drop-panel-width: 240px;
+}
+
 .react-flow__node {
     position: absolute;
     -webkit-user-select: none;

--- a/packages/graph-editor/src/redux/models/ui.ts
+++ b/packages/graph-editor/src/redux/models/ui.ts
@@ -9,7 +9,7 @@ export interface UIState {
 
 export const uiState = createModel<RootModel>()({
   state: {
-    showNodesPanel: true,
+    showNodesPanel: false,
     showNodesCmdPalette: false,
     storeNodeInsertPosition: { x: 0, y: 0 },
   } as UIState,

--- a/packages/graph-editor/src/redux/models/ui.ts
+++ b/packages/graph-editor/src/redux/models/ui.ts
@@ -9,7 +9,7 @@ export interface UIState {
 
 export const uiState = createModel<RootModel>()({
   state: {
-    showNodesPanel: false,
+    showNodesPanel: true,
     showNodesCmdPalette: false,
     storeNodeInsertPosition: { x: 0, y: 0 },
   } as UIState,

--- a/packages/ui/src/assets/svgs/AppsIcon.svg
+++ b/packages/ui/src/assets/svgs/AppsIcon.svg
@@ -1,0 +1,43 @@
+<svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.75 6.75V8.25C4.75 9.35457 5.64543 10.25 6.75 10.25H8.25C9.35457 10.25 10.25 9.35457 10.25 8.25V6.75C10.25 5.64543 9.35457 4.75 8.25 4.75H6.75C5.64543 4.75 4.75 5.64543 4.75 6.75Z"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M14.75 7H19.25"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M17 4.75L17 9.25"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M4.75 15.75V17.25C4.75 18.3546 5.64543 19.25 6.75 19.25H8.25C9.35457 19.25 10.25 18.3546 10.25 17.25V15.75C10.25 14.6454 9.35457 13.75 8.25 13.75H6.75C5.64543 13.75 4.75 14.6454 4.75 15.75Z"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M13.75 15.75V17.25C13.75 18.3546 14.6454 19.25 15.75 19.25H17.25C18.3546 19.25 19.25 18.3546 19.25 17.25V15.75C19.25 14.6454 18.3546 13.75 17.25 13.75H15.75C14.6454 13.75 13.75 14.6454 13.75 15.75Z"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>

--- a/packages/ui/src/components/EmptyStateEditor.tsx
+++ b/packages/ui/src/components/EmptyStateEditor.tsx
@@ -1,3 +1,4 @@
+import { showNodesPanelSelector } from '#/redux/selectors/index.ts';
 import {
   BatteryChargingIcon,
   FilePlusIcon,
@@ -6,7 +7,7 @@ import {
 import { Box, Button, EmptyState, Stack } from '@tokens-studio/ui';
 import { useCallback } from 'react';
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 interface IEmptyStateProps {
   onLoadExamples: () => void;
@@ -14,6 +15,7 @@ interface IEmptyStateProps {
 
 export function EmptyStateEditor({ onLoadExamples }: IEmptyStateProps) {
   const dispatch = useDispatch();
+  const showNodesPanel = useSelector(showNodesPanelSelector);
 
   const handleTriggerAddNode = useCallback(
     (e) => {
@@ -40,6 +42,7 @@ export function EmptyStateEditor({ onLoadExamples }: IEmptyStateProps) {
         height: '100%',
         position: 'relative',
         zIndex: 100,
+        paddingLeft: showNodesPanel ? 'var(--globals-drop-panel-width)' : '0',
       }}
     >
       <EmptyState

--- a/packages/ui/src/components/editor/index.tsx
+++ b/packages/ui/src/components/editor/index.tsx
@@ -8,7 +8,7 @@ import React, { useCallback } from 'react';
 import { useTheme } from '#/hooks/useTheme.tsx';
 import { EmptyStateEditor } from '../EmptyStateEditor.tsx';
 import { ExamplesPicker } from '../ExamplesPicker.tsx';
-import { showExamplePickerSelector } from '#/redux/selectors/index.ts';
+import { showExamplePickerSelector, showNodesPanelSelector } from '#/redux/selectors/index.ts';
 import { useSelector } from 'react-redux';
 import { useRouter } from 'next/router.js';
 import { useGetEditor } from '#/hooks/useGetEditor.ts';
@@ -18,11 +18,19 @@ import { previewCodeSelector } from '#/redux/selectors/index.ts';
 export const EditorTab = ({ ...rest }) => {
   const dispatch = useDispatch();
   const previewCode = useSelector(previewCodeSelector);
+  const shouldShowNodesPanel = useSelector(showNodesPanelSelector);
   const [, ref] = useRegisterRef('editor');
   const [, setCodeRef] = useRegisterRef('codeEditor');
   const showExamplePicker = useSelector(showExamplePickerSelector);
   const [loading, setLoading] = React.useState(false);
   const { loadExample } = useGetEditor();
+
+  const onShowNodesPanelChange = useCallback(
+    (value: boolean) => {
+      dispatch.ui.setShowNodesPanel(value);
+    },
+    [dispatch.ui],
+  );
 
   const router = useRouter();
   const loadParam = router.query.load;
@@ -71,6 +79,8 @@ export const EditorTab = ({ ...rest }) => {
         id={'editor'}
         ref={ref}
         onOutputChange={onEditorOutputChange}
+        shouldShowNodesPanel={shouldShowNodesPanel}
+        onShowNodesPanelChange={onShowNodesPanelChange}
         menuContent={
           <Menubar
             toggleTheme={toggleTheme}

--- a/packages/ui/src/components/editorMenu/index.tsx
+++ b/packages/ui/src/components/editorMenu/index.tsx
@@ -9,12 +9,16 @@ import {
 } from '@iconicicons/react';
 import SlackIcon from '#/assets/svgs/slack.svg';
 import YoutubeIcon from '#/assets/svgs/youtube.svg';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { ResolverData } from '#/types/file.ts';
 import { getRectOfNodes, getTransformForBounds } from 'reactflow';
 import { Box, IconButton, Stack } from '@tokens-studio/ui';
 import { toPng } from 'html-to-image';
 import { store } from '#/redux/store.tsx';
+import AppsIcon from '#/assets/svgs/AppsIcon.svg';
+import { showNodesPanelSelector } from '#/redux/selectors/index.ts';
+import { useSelector } from 'react-redux';
+import { useDispatch } from '#/hooks/useDispatch.ts';
 
 const imageWidth = 1024;
 const imageHeight = 768;
@@ -32,12 +36,17 @@ export const Menubar = ({
   previewCode: string;
   setPreviewCode: (code: string) => void;
 }) => {
+
+  const showNodesPanel = useSelector(showNodesPanelSelector);
+  const dispatch = useDispatch();
+
   const findCurrentEditor = useCallback(() => {
     const activeEditor = store.getState().refs.editor;
 
     return activeEditor;
   }, []);
 
+  // TODO: Move all of this to a hook
   const onSave = useCallback(() => {
     const editor = findCurrentEditor();
 
@@ -72,6 +81,8 @@ export const Menubar = ({
     document.body.removeChild(link);
   }, [previewCode, findCurrentEditor]);
 
+
+  // TODO: Move all of this to a hook
   const onLoad = useCallback(() => {
     const editor = findCurrentEditor();
     if (!editor) {
@@ -113,6 +124,8 @@ export const Menubar = ({
     input.click();
   }, [findCurrentEditor, setPreviewCode]);
 
+
+  // TODO: Move all of this to a hook
   const onPrint = useCallback(async () => {
     function downloadImage(dataUrl) {
       const a = document.createElement('a');
@@ -163,7 +176,13 @@ export const Menubar = ({
       gap={2}
       css={{ flexGrow: 1 }}
     >
-      <Stack direction="column">
+      <Stack direction="column" css={{backgroundColor: '$bgDefault', padding: '$2', borderRadius: '$medium', border: '1px solid', borderColor: '$borderSubtle', boxShadow: '$small'}}>
+        <IconButton
+          tooltip="Add nodes (n)"
+          onClick={() => dispatch.ui.setShowNodesPanel(!showNodesPanel)}
+          icon={<AppsIcon />}
+          variant={showNodesPanel ? 'primary' : 'invisible'}
+        />
         <Box
           css={{
             height: '1px',

--- a/packages/ui/src/pages/index.tsx
+++ b/packages/ui/src/pages/index.tsx
@@ -61,6 +61,7 @@ const Wrapper = () => {
           height: '100%',
           overflow: 'hidden',
           background: '$bgDefault',
+          isolation: 'isolate'
         }}
       >
         <LiveProvider

--- a/packages/ui/src/redux/models/ui.ts
+++ b/packages/ui/src/redux/models/ui.ts
@@ -14,6 +14,7 @@ export interface UIState {
   tabs: Tab[];
   theme: string;
   showExamplePicker: boolean;
+  showNodesPanel: boolean;
 }
 
 const starting = [
@@ -30,6 +31,7 @@ export const uiState = createModel<RootModel>()({
     tabs: starting,
     theme: 'dark',
     showExamplePicker: false,
+    showNodesPanel: true,
   } as UIState,
   reducers: {
     setTheme(state, theme: string) {
@@ -64,6 +66,12 @@ export const uiState = createModel<RootModel>()({
       return {
         ...state,
         showExamplePicker,
+      };
+    },
+    setShowNodesPanel(state, showNodesPanel: boolean) {
+      return {
+        ...state,
+        showNodesPanel,
       };
     },
     setPreviewCode(state, previewCode: string) {

--- a/packages/ui/src/redux/selectors/index.ts
+++ b/packages/ui/src/redux/selectors/index.ts
@@ -9,6 +9,10 @@ export const previewCodeSelector = createSelector(
   ui,
   (state) => state.previewCode,
 );
+export const showNodesPanelSelector = createSelector(
+  ui,
+  (state) => state.showNodesPanel,
+);
 
 export const outputSelector = (state: RootState) => state.editorOutput;
 


### PR DESCRIPTION
Adds support to control visibility of `nodesPanel` externally and adjusts style of the playground menu to adjust to our Studio UI and fit in without feeling like yet another column

- Added new props to the editor: `showNodesPanel` and `onShowNodesPanelChange` to make appearance of nodes panel optional and controllable.
- Fixed vertical scroll of nodes panel

### Menu style

<img width="1333" alt="CleanShot 2023-12-10 at 12 55 44@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/74929150-13d3-4c35-a53f-373e99bf6beb">

### Default without menu open

<img width="1331" alt="CleanShot 2023-12-10 at 12 56 37@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/bf128743-7405-44f6-98f5-706118c94f50">

### Vertical scroll of nodes panel

<img width="531" alt="CleanShot 2023-12-10 at 12 55 58@2x" src="https://github.com/tokens-studio/graph-engine/assets/4548309/16cef66f-ae52-451e-924f-aefd5d23cd44">
