### PR TITLE
Refactor editor layout and menu

### DIFF
--- a/.changeset/many-starfishes-relax.md
+++ b/.changeset/many-starfishes-relax.md
@@ -1,0 +1,6 @@
+---
+"@tokens-studio/graph-editor": minor
+"@tokens-studio/graph-engine-ui": minor
+---
+
+Prevent toolpanel from covering canvas

--- a/packages/graph-editor/src/editor/index.tsx
+++ b/packages/graph-editor/src/editor/index.tsx
@@ -70,7 +70,7 @@ const snapGridCoords: SnapGrid = [16, 16];
 const defaultViewport = { x: 0, y: 0, zoom: 1.5 };
 const panOnDrag = [1, 2];
 
-const noop = () => {};
+const noop = () => { };
 
 const edgeTypes = {
   custom: CustomEdge,
@@ -509,67 +509,57 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
     return (
       <>
         <GlobalHotKeys keyMap={keyMap} handlers={handlers} allowChanges>
-          <Box
+          <Stack
             className="editor"
+            direction='row'
             css={{
               height: '100%',
               backgroundColor: '$bgCanvas',
-              display: 'flex',
-              flexDirection: 'row',
               flexGrow: 1,
             }}
           >
             <ForceUpdateProvider value={forceUpdate}>
-              <Box
-                css={{
-                  position: 'absolute',
-                  zIndex: 500,
-                  display: 'flex',
-                  flexDirection: 'row',
-                  height: 'inherit',
-                }}
-              >
-                {showMenu && (
-                  <Stack
-                    direction="column"
-                    gap={2}
-                    css={{
-                      position: 'relative',
-                      padding: '$3',
-                      paddingRight: 0,
-                      zIndex: 600,
-                    }}
-                  >
-                    {props.menuContent}
-                    <Settings />
-                  </Stack>
-                )}
-                {showNodesPanel && (
-                  <Box
-                    css={{
-                      paddingLeft: '$3',
-                      paddingTop: '$3',
-                      paddingBottom: '$3',
-                    }}
-                  >
-                    <Box
-                      css={{
-                        backgroundColor: '$bgDefault',
-                        width: 'var(--globals-drop-panel-width)',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        border: '1px solid $borderSubtle',
-                        boxShadow: '$small',
-                        borderRadius: '$medium',
-                        overflowY: 'auto',
-                        maxHeight: '100%',
-                      }}
-                    >
-                      <DropPanel groups={[]} items={panelItems} />
-                    </Box>
-                  </Box>
-                )}
-              </Box>
+
+              {showMenu && (
+                <Stack
+                  direction="column"
+                  align='center'
+                  justify='center'
+                  gap={2}
+                  css={{
+                    position: 'relative',
+                    paddingTop: '$3',
+                    zIndex: 600,
+                    backgroundColor: '$bgCanvas',
+                    width: 'var(--globals-sidebar-width)',
+                    borderRight: '1px solid $borderMuted',
+                  }}
+                >
+                  {props.menuContent}
+                  <Settings />
+                </Stack>
+              )}
+              {showNodesPanel && (
+                <Stack
+                  css={{
+                    position: 'absolute',
+                    backgroundColor: '$bgDefault',
+                    border: '1px solid $borderMuted',
+                    width: 'var(--globals-drop-panel-width)',
+                    left: 'calc(var(--globals-sidebar-width) + $3)',
+                    top: '$3',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    boxShadow: '$small',
+                    borderRadius: '$medium',
+                    overflowY: 'auto',
+                    height: 'fit-content'
+                  }}
+                >
+                  <DropPanel groups={[]} items={panelItems} />
+                </Stack>
+              )}
+
               <ReactFlow
                 ref={reactFlowWrapper}
                 fitView
@@ -627,7 +617,7 @@ export const EditorApp = React.forwardRef<ImperativeEditorRef, EditorProps>(
                 {props.children}
               </ReactFlow>
             </ForceUpdateProvider>
-          </Box>
+          </Stack>
         </GlobalHotKeys>
         <PaneContextMenu
           id={props.id + '_pane'}

--- a/packages/graph-editor/src/index.css
+++ b/packages/graph-editor/src/index.css
@@ -3,6 +3,7 @@
 
 :root {
     --globals-drop-panel-width: 240px;
+    --globals-sidebar-width: 60px;
 }
 
 .react-flow__node {

--- a/packages/ui/src/components/editorMenu/index.tsx
+++ b/packages/ui/src/components/editorMenu/index.tsx
@@ -219,7 +219,7 @@ export const Menubar = ({
           onClick={onLoadExamples}
         />
       </Stack>
-      <Stack direction="column" justify="end" css={{ flexGrow: 1 }}>
+      <Stack direction="column" justify="end" css={{ flexGrow: 1 }} align='center'>
         <IconButton
           variant="invisible"
           tooltip={theme === 'light' ? 'Dark mode' : 'Light mode'}


### PR DESCRIPTION
## **User description**
Panel was covering the canvas an you could not select a node that was positioned under the side panel

https://github.com/tokens-studio/graph-engine/assets/21245398/871761dd-6a2c-4c3b-9031-87e87facdb6a


___

## **Type**
enhancement


___

## **Description**
- Refactored the editor layout to improve usability and accessibility by changing the layout container and adjusting the positioning of the menu and nodes panel.
- Center aligned the bottom stack in the editor menu for a cleaner look.
- Introduced a new CSS variable for sidebar width to standardize the layout.
- Updated package versions to reflect the enhancements made.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Refactor Editor Layout for Improved Usability and Accessibility</code></dd></summary>
<hr>

packages/graph-editor/src/editor/index.tsx
<li>Changed layout container from <code>Box</code> to <code>Stack</code> with row direction for <br>better structure.<br> <li> Improved positioning and styling of menu and nodes panel for better <br>visibility and accessibility.<br> <li> Adjusted <code>ReactFlow</code> component and its surrounding context to fit new <br>layout adjustments.


</details>
    

  </td>
  <td><a href="https:/tokens-studio/graph-engine/pull/239/files#diff-040b33aca283c67e672eff3eb4193de193c13e811b2c402fa1ef37242e8b8074">+45/-55</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Center Align Bottom Stack in Editor Menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/components/editorMenu/index.tsx
- Aligned the bottom stack in the editor menu to center.


</details>
    

  </td>
  <td><a href="https:/tokens-studio/graph-engine/pull/239/files#diff-c6b3e97e8fcf61e25012e3f88d855922998822155b8576fe9966e27cb2a8d439">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.css</strong><dd><code>Add Sidebar Width CSS Variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/index.css
- Introduced a new CSS variable for sidebar width.


</details>
    

  </td>
  <td><a href="https:/tokens-studio/graph-engine/pull/239/files#diff-e389b4f156cbf1afd3bf717777d7a9213b9d6a84504bf8439bde968c067d7116">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>many-starfishes-relax.md</strong><dd><code>Version Bump and Enhancement Note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/many-starfishes-relax.md
<li>Minor version bump for <code>@tokens-studio/graph-editor</code> and <br><code>@tokens-studio/graph-engine-ui</code>.<br> <li> Describes the enhancement to prevent the tool panel from covering the <br>canvas.


</details>
    

  </td>
  <td><a href="https:/tokens-studio/graph-engine/pull/239/files#diff-13ad738a151187f4f7cdd217107e2c94262a297757b97b6445c6a5792fa3d90f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

