### PR TITLE
Freeze extract-colors version to 4.0.2 because their 4.0.3 is broken

### DIFF
--- a/packages/graph-engine/package.json
+++ b/packages/graph-engine/package.json
@@ -45,7 +45,7 @@
     "colorjs.io": "^0.4.3",
     "culori": "^3.1.2",
     "dot-prop": "^8.0.2",
-    "extract-colors": "^4.0.2",
+    "extract-colors": "4.0.2",
     "get-pixels": "^3.3.3",
     "is-promise": "^4.0.0",
     "lodash.orderby": "^4.6.0",


### PR DESCRIPTION
Source maps in extract-colors 4.0.3 package are broken. Some bundlers (vite for sure) may not be able to parse this source map.

![image](https://github.com/tokens-studio/graph-engine/assets/15103616/54d1f071-9ca1-47ab-ba15-64a7de76e5d2)
