### PR TITLE
add xyz65 to color convert

### DIFF
--- a/packages/graph-engine/src/nodes/color/convert.ts
+++ b/packages/graph-engine/src/nodes/color/convert.ts
@@ -1,12 +1,12 @@
-import { INodeDefinition, ToInput, ToOutput } from "../../index.js";
 import { Color, NodeTypes } from "../../types.js";
-import { Node } from "../../programmatic/node.js";
-import { Rgb, Lab, Hsl, converter } from "culori";
 import {
   ColorSchema,
   NumberSchema,
   StringSchema,
 } from "../../schemas/index.js";
+import { Hsl, Lab, Rgb, Xyz65, converter } from "culori";
+import { INodeDefinition, ToInput, ToOutput } from "../../index.js";
+import { Node } from "../../programmatic/node.js";
 import { arrayOf } from "../../schemas/utils.js";
 
 export const colorSpaces = [
@@ -23,9 +23,11 @@ export const colorSpaces = [
   "rec2020",
 
   //LAB like
-
   "dlab",
   "lab65",
+
+  //XYZ
+  "xyz65",
 
   //HSL like
   "okhsl",
@@ -169,6 +171,19 @@ export default class NodeDefinition extends Node {
             d: col.alpha,
             channels: [col.l, col.a, col.b, col.alpha],
             labels: ["l", "a", "b", "alpha"],
+          };
+        }
+        break;
+      case "xyz65":
+        {
+          const col: Xyz65 = output as unknown as Xyz65;
+          final = {
+            a: col.x,
+            b: col.y,
+            c: col.z,
+            d: col.alpha,
+            channels: [col.x, col.y, col.z, col.alpha],
+            labels: ["x", "y", "z", "alpha"],
           };
         }
         break;


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added support for `xyz65` color space in the color conversion module.
- Updated the import statements to include `Xyz65` from `culori`.
- Included `xyz65` in the `colorSpaces` array.
- Implemented case handling for `xyz65` in the color conversion logic to handle its specific channels and labels.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convert.ts</strong><dd><code>Add support for `xyz65` color space in color conversion</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-engine/src/nodes/color/convert.ts
<li>Added support for <code>xyz65</code> color space in color conversion.<br> <li> Imported <code>Xyz65</code> from <code>culori</code>.<br> <li> Updated <code>colorSpaces</code> array to include <code>xyz65</code>.<br> <li> Added case handling for <code>xyz65</code> in the color conversion logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/264/files#diff-9756d163149396de008c5250dd12d904664d5ca45ed610ba74f76872b32e608c">+19/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

