### PR TITLE
Fix flatten node

### DIFF
--- a/packages/graph-editor/src/hooks/useIsValidConnection.ts
+++ b/packages/graph-editor/src/hooks/useIsValidConnection.ts
@@ -36,13 +36,15 @@ export const useIsValidConnection = ({
       }
 
       const strippedVariadic = stripVariadic(connection.targetHandle!);
-
+      
       let targetType = target?.inputs[strippedVariadic].type!;
-      const sourceType = source?.outputs[connection.sourceHandle!].type!;
+      let sourceType = source?.outputs[connection.sourceHandle!].type!;
 
-      //Check if the target is variadic
-      if (target.inputs[strippedVariadic].variadic) {
+      if (target.inputs[strippedVariadic].type.items) {
         targetType = target.inputs[strippedVariadic].type.items;
+      }
+      if (source.outputs[connection.sourceHandle!].type.items) {
+        sourceType = source.outputs[connection.sourceHandle!].type.items;
       }
 
       const canConvert = canConvertSchemaTypes(sourceType, targetType);

--- a/packages/nodes-design-tokens/src/nodes/flatten.ts
+++ b/packages/nodes-design-tokens/src/nodes/flatten.ts
@@ -11,7 +11,7 @@ export default class FlattenNode extends Node {
     super(props);
     this.addInput("tokens", {
       type: {
-        ...createVariadicSchema(TokenSetSchema),
+        ...createVariadicSchema(TokenSchema),
         default: [],
       },
       variadic: true,

--- a/packages/nodes-design-tokens/src/ui/controls/index.tsx
+++ b/packages/nodes-design-tokens/src/ui/controls/index.tsx
@@ -3,10 +3,13 @@ import { TokenArrayField } from "./tokenSet.js"
 import { TokenField } from "./token.js"
 import { VariadicTokenSet } from "./variadicTokenSet.js"
 import { variadicMatcher } from "@tokens-studio/graph-editor"
-import type { Port } from "@tokens-studio/graph-engine"
+import type { Input, Port } from "@tokens-studio/graph-engine"
 
 export const controls = [{
-    matcher: (port: Port) => port.type.type === 'array' && port.type.items?.$id === TOKEN,
+    matcher: (port: Port) => {
+        const inputPort = port as Input;
+        return inputPort.type.type === 'array' && inputPort.type.items?.$id === TOKEN && !inputPort.variadic
+    },
     component: TokenArrayField,
 },
 {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed handling of variadic types for source and target connections in `useIsValidConnection` hook.
- Updated input type from `TokenSetSchema` to `TokenSchema` in `FlattenNode`.
- Enhanced matcher function in UI controls to handle `Input` type and exclude variadic inputs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useIsValidConnection.ts</strong><dd><code>Fix and enhance variadic type handling in connections.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/hooks/useIsValidConnection.ts
<li>Fixed handling of variadic types for source and target connections.<br> <li> Added checks for <code>type.items</code> to correctly handle nested types.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/265/files#diff-ac8ba0feb3db9e819425c4d9cb4d01c4497cb1424e8d6b7f3c1b62b68e8b55c0">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flatten.ts</strong><dd><code>Update input type in FlattenNode to TokenSchema.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nodes-design-tokens/src/nodes/flatten.ts
<li>Changed input type from <code>TokenSetSchema</code> to <code>TokenSchema</code> in <code>FlattenNode</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/265/files#diff-1fffc46a65ac7fa786425325f165fc9d94a2a38d4449b11ae6892cfa985b7c9d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Enhance matcher function to handle Input type and exclude variadic.</code></dd></summary>
<hr>

packages/nodes-design-tokens/src/ui/controls/index.tsx
<li>Added type casting for <code>port</code> to <code>Input</code> in matcher function.<br> <li> Enhanced matcher function to exclude variadic inputs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/265/files#diff-6569d5a55a38ae213ab5dc1a2c5f7092e65952888b597f89186cc4bd2dccdb95">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

