### PR TITLE
fix(1013): Subgraph output

### DIFF
--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -15,7 +15,7 @@ import { useLocalGraph } from '@/context/graph.js';
 
 const isHexColor = (str) => {
   if (typeof str !== 'string') return false;
-  return /^#(?:[0-9a-fA-F]{3}){1,2}$/.test(str);;
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(str);;
 };
 
 export type UiNodeDefinition = {
@@ -156,7 +156,7 @@ const getColorPreview = (color: string, showValue = false) => {
   return (
     <Stack direction="row" gap={2}>
       {colorSwatch}    
-      {showValue ? <Text css={{ fontSize: '$small', color: '$gray12' }}>{color}</Text> : null}
+      {showValue ? <Text css={{ fontSize: '$small', color: '$gray12' }}>{color.toUpperCase()}</Text> : null}
     </Stack>
   );
 }

--- a/packages/graph-engine/src/nodes/generic/subgraph.ts
+++ b/packages/graph-engine/src/nodes/generic/subgraph.ts
@@ -39,6 +39,11 @@ export default class SubgraphNode extends Node {
     this._innerGraph.addNode(input);
     this._innerGraph.addNode(output);
 
+    this.addOutput("value", {
+      type: AnySchema,
+      visible: true,
+    });
+
     autorun(() => {
 
       //Get the existing inputs 
@@ -94,11 +99,10 @@ export default class SubgraphNode extends Node {
       return acc;
     }, {});
 
-
     const result = await this._innerGraph.execute({
       inputs
     });
 
-    this.setOutput("value", result.output?.value, result.output?.type);
+    this.setOutput("value", result.output?.value.value, result.output?.value.type);
   }
 }


### PR DESCRIPTION
### **User description**
- When creating a subgraph the output is now shown on the subgraph node
- Show HEX8 in color swatches preview
- show uppercase hex colors


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enhanced hex color validation to support 8-character hex codes.
- Modified color display to show uppercase hex values in the preview.
- Added an output node to subgraph with visible type.
- Fixed the output value assignment to correctly access nested value.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodeV2.tsx</strong><dd><code>Enhance hex color validation and display formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
<li>Updated hex color validation to include 8-character hex codes.<br> <li> Modified color display to show uppercase hex values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/267/files#diff-22c64f79290285f9b5524bf34746fe5aba1d1ef1100277adfd1fd2403621c07d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subgraph.ts</strong><dd><code>Fix subgraph output node and value assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-engine/src/nodes/generic/subgraph.ts
<li>Added an output node to subgraph with visible type.<br> <li> Fixed the output value assignment to correctly access nested value.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/267/files#diff-f5c1a0ca6c8b3ed2623a20e1596b3293fef42f458ea0ba03325a31b676e67512">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

