### PR TITLE
prevent delete when annotation is present

### DIFF
--- a/packages/graph-editor/src/components/contextMenus/nodeContextMenu.tsx
+++ b/packages/graph-editor/src/components/contextMenus/nodeContextMenu.tsx
@@ -10,6 +10,8 @@ import { Graph } from 'graphlib';
 import { useAction } from '@/editor/actions/provider';
 import { graph } from '@/redux/selectors';
 import { useLocalGraph } from '@/hooks';
+import { useCanDeleteNode } from '@/hooks/useCanDeleteNode';
+import { useToast } from '@/hooks/useToast';
 
 export interface INodeContextMenuProps {
   id: string;
@@ -72,11 +74,19 @@ export const NodeContextMenu = ({
   id,
   nodes,
 }: INodeContextMenuProps) => {
+  const trigger = useToast();
   const reactFlowInstance = useReactFlow();
   const duplicateNodes = useAction('duplicateNodes');
   const graph = useLocalGraph();
 
+  const isDeletable = useCanDeleteNode(nodes?.[0]?.id);
+
   const deleteEl = useCallback(() => {
+    if (isDeletable) {
+      trigger({ title: 'Node is not deletable', description: 'This node cannot be deleted' })
+      return;
+    }
+
     if (nodes) {
       reactFlowInstance.deleteElements({ nodes });
     }
@@ -143,7 +153,7 @@ export const NodeContextMenu = ({
 
   const forceExecution = useCallback(() => {
     if (nodes) {
- 
+
       nodes.forEach((node) => {
         const graphNode = graph.getNode(node.id);
         if (graphNode) {
@@ -151,13 +161,13 @@ export const NodeContextMenu = ({
         }
       });
     }
-  },[graph, nodes]);
+  }, [graph, nodes]);
 
   return (
     <Menu id={id}>
       <Item onClick={onDuplicate}>Duplicate</Item>
       <Item onClick={focus}>Focus</Item>
-      <Item onClick={deleteEl}>Delete</Item>
+      <Item disabled={!isDeletable} onClick={deleteEl}>Delete</Item>
       <Item onClick={forceExecution}>Force Execution</Item>
       <Separator />
       {nodes?.length == 1 && (

--- a/packages/graph-editor/src/components/hotKeys/index.tsx
+++ b/packages/graph-editor/src/components/hotKeys/index.tsx
@@ -12,6 +12,7 @@ import { HotKeys as HotKeysComp } from 'react-hotkeys';
 import { useAction } from '@/editor/actions/provider';
 import { useAutoLayout } from '@/editor/hooks/useAutolayout';
 import React from 'react';
+import { annotatedDeleteable } from '@tokens-studio/graph-engine';
 
 export const keyMap = {
     AUTO_LAYOUT: 'ctrl+alt+f',
@@ -58,7 +59,6 @@ export const useHotkeys = () => {
     const duplicateNodes = useAction('duplicateNodes');
     const deleteNode = useAction('deleteNode');
     const copyNodes = useAction('copyNodes');
-
     const layout = useAutoLayout();
 
     const dispatch = useDispatch();
@@ -110,6 +110,11 @@ export const useHotkeys = () => {
                 const selectedNodes = reactFlowInstance.getNodes().filter((x) => x.selected).map((x) => x.id);
 
                 selectedNodes.forEach((id) => {
+                    const edgeNode = graph.getNode(id);
+                    if (edgeNode?.annotations[annotatedDeleteable] === false) {
+                        trigger({ title: 'Node not deletable', description: `Node ${edgeNode.nodeType()} is not deletable` });
+                        return;
+                    }
                     deleteNode(id);
                 });
 

--- a/packages/graph-editor/src/hooks/useCanDeleteNode.ts
+++ b/packages/graph-editor/src/hooks/useCanDeleteNode.ts
@@ -1,0 +1,15 @@
+import { annotatedDeleteable } from "@tokens-studio/graph-engine";
+import { useLocalGraph } from "./useLocalGraph";
+
+export const useCanDeleteNode = (nodeId: string) => {
+    const graph = useLocalGraph();
+    const node = graph.getNode(nodeId);
+
+    if (node) {
+        if (node.annotations[annotatedDeleteable] === false) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
### **User description**
https://github.com/tokens-studio/graph-engine/assets/21245398/33b0ea1a-b0ed-4023-8fde-39c8e5e977e1


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `useCanDeleteNode` and `useToast` hooks to the node context menu component.
- Implemented logic to prevent deletion of nodes with specific annotations in both context menu and hotkeys.
- Updated the `Delete` menu item to be disabled if the node is not deletable.
- Created a new hook `useCanDeleteNode` to encapsulate the logic for checking if a node is deletable.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodeContextMenu.tsx</strong><dd><code>Prevent deletion of nodes with specific annotations in context menu.</code></dd></summary>
<hr>

packages/graph-editor/src/components/contextMenus/nodeContextMenu.tsx
<li>Added <code>useCanDeleteNode</code> and <code>useToast</code> hooks.<br> <li> Implemented logic to prevent deletion of nodes with specific <br>annotations.<br> <li> Updated the <code>Delete</code> menu item to be disabled if the node is not <br>deletable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/281/files#diff-dc19e79194a2a8ff677d87d0326c3a99e89d0f36f0c3aba76a41f72261b152e0">+13/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Prevent deletion of nodes with specific annotations via hotkeys.</code></dd></summary>
<hr>

packages/graph-editor/src/components/hotKeys/index.tsx
<li>Added <code>annotatedDeleteable</code> import.<br> <li> Implemented logic to prevent deletion of nodes with specific <br>annotations via hotkeys.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/281/files#diff-81d69f0317bc0fa978d507e9dd5b34b0e994415f50009866790ae026ae4dea14">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useCanDeleteNode.ts</strong><dd><code>Add hook to check if a node is deletable.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/hooks/useCanDeleteNode.ts
<li>Created a new hook <code>useCanDeleteNode</code> to check if a node is deletable <br>based on annotations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/281/files#diff-1ed514f5e59493314b4d8f95d9a4940fa098e1996717fcb2685fbe2dff573995">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

