### PR TITLE
fix position reference

### DIFF
--- a/packages/graph-editor/src/editor/actions/duplicate.ts
+++ b/packages/graph-editor/src/editor/actions/duplicate.ts
@@ -41,6 +41,7 @@ export const duplicateNodes = ({ graph, reactFlowInstance, nodeLookup }: IDuplic
                     ...saved,
                     id: newID,
                     annotations: {
+                        ...saved.annotations,
                         'ui.position.x': newPosition.x,
                         'ui.position.y': newPosition.y,
                     }

--- a/packages/graph-editor/src/editor/actions/duplicate.ts
+++ b/packages/graph-editor/src/editor/actions/duplicate.ts
@@ -31,14 +31,22 @@ export const duplicateNodes = ({ graph, reactFlowInstance, nodeLookup }: IDuplic
             }
             const newID = uuidv4();
             const saved = graphNode.serialize();
+            const newPosition = {
+                x: node.position.x + 20,
+                y: node.position.y + 100,
+            }
 
             const newGraphNode = graphNode?.factory.deserialize({
                 serialized: {
                     ...saved,
                     id: newID,
+                    annotations: {
+                        'ui.position.x': newPosition.x,
+                        'ui.position.y': newPosition.y,
+                    }
                 },
                 graph,
-                lookup: nodeLookup
+                lookup: nodeLookup,
             }
             );
 
@@ -71,10 +79,7 @@ export const duplicateNodes = ({ graph, reactFlowInstance, nodeLookup }: IDuplic
                 ...node,
                 id: newID,
                 selected: true,
-                position: {
-                    x: node.position.x + 20,
-                    y: node.position.y + 100,
-                },
+                position: newPosition,
             }];
 
 


### PR DESCRIPTION
### **User description**
* When duplicating a node if position is not set we are left with a reference to the duplicated node. When setting new position it alters both objects.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where duplicating a node without setting a new position would result in a reference to the original node's position.
- Added new position calculation directly in the node deserialization process to ensure unique positions for duplicated nodes.
- Removed redundant position setting to avoid altering both original and duplicated nodes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>duplicate.ts</strong><dd><code>Fix position reference issue in node duplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/actions/duplicate.ts
<li>Added new position calculation for duplicated nodes.<br> <li> Updated node deserialization to include new position.<br> <li> Removed redundant position setting in node duplication.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/298/files#diff-ac059cd5016eb9fad4bd16c7ed98c4834367e722b0dfb0cd40ae5c62e66c1d97">+10/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

