### PR TITLE
Fix default import

### DIFF
--- a/.changeset/dry-donkeys-cheer.md
+++ b/.changeset/dry-donkeys-cheer.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fix CSS properties import for CSS map node

--- a/packages/graph-editor/src/registry/inputControls.tsx
+++ b/packages/graph-editor/src/registry/inputControls.tsx
@@ -12,7 +12,7 @@ import { observer } from 'mobx-react-lite';
 import React, { useMemo } from 'react';
 import { Node } from '@tokens-studio/graph-engine';
 
-import * as properties from 'mdn-data/css/properties.json' ;
+import properties from 'mdn-data/css/properties.json';
 import { deletable } from '@/annotations';
 
 const CSSProperties = Object.keys(properties);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the import statement for `mdn-data/css/properties.json` to use default import in `packages/graph-editor/src/registry/inputControls.tsx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inputControls.tsx</strong><dd><code>Fix default import for `mdn-data/css/properties.json`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/registry/inputControls.tsx
<li>Fixed the import statement for <code>mdn-data/css/properties.json</code> to use <br>default import.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/313/files#diff-37917d4929074313fb7e01f0365a5368bb8ef958713c60948d79403817fd0377">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

