### PR TITLE
Add error boundary component

### DIFF
--- a/.changeset/angry-dolls-call.md
+++ b/.changeset/angry-dolls-call.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Add error boundaries to the graph editor panels

--- a/packages/graph-editor/package.json
+++ b/packages/graph-editor/package.json
@@ -71,7 +71,7 @@
     "rc-menu": "^9.12.4",
     "react-colorful": "^5.6.1",
     "react-contexify": "^6.0.0",
-    "react-error-boundary": "^4.0.11",
+    "react-error-boundary": "^4.0.13",
     "react-flame-graph": "^1.4.0",
     "react-hotkeys": "2.0.0",
     "react-json-tree": "^0.18.0",

--- a/packages/graph-editor/src/components/ErrorBoundaryContent.tsx
+++ b/packages/graph-editor/src/components/ErrorBoundaryContent.tsx
@@ -1,0 +1,44 @@
+import { Button, Stack, Text } from '@tokens-studio/ui'
+import React from 'react'
+import { ImperativeEditorRef, mainGraphSelector } from '..';
+import { useSelector } from 'react-redux';
+import { title } from '@/annotations';
+
+export const ErrorBoundaryContent: React.FunctionComponent = () => {
+  const mainGraph = useSelector(mainGraphSelector);
+  const graphRef = mainGraph?.ref as (ImperativeEditorRef | undefined);
+
+  const onSave = () => {
+    const saved = graphRef!.save();
+    const blob = new Blob([JSON.stringify(saved)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = (saved.annotations[title] || 'graph') + `.json`;
+    document.body.appendChild(link);
+    link.click();
+  };
+
+  return (
+    <Stack css={{ width: '100%', height: '100%', padding: '$4' }} align='center' justify='center'>
+      <Stack direction='column' gap={4} align='center' justify='center'>
+        <Text css={{ fontSize: '$large', textAlign: 'center' }}>Uh-oh, something went wrong!</Text>
+        {graphRef ? (
+          <Text css={{ textAlign: 'center' }}>It looks like an error occurred. You can download your current progress and contact support.</Text>
+        ) : (
+          <>
+            <Text css={{ textAlign: 'center' }}>It looks like an error occurred. Try reloading the page.</Text>
+            <Button onClick={() => {
+              window.location.reload();
+            }}>Reload page</Button>
+          </>
+        )}
+        {graphRef && (
+          <Button onClick={onSave}>Download graph</Button>
+        )}
+      </Stack>
+    </Stack>
+  )
+}

--- a/packages/graph-editor/src/editor/layoutController.tsx
+++ b/packages/graph-editor/src/editor/layoutController.tsx
@@ -19,11 +19,12 @@ import { dockerSelector } from '@/redux/selectors/refs.js';
 import { useDispatch } from '@/hooks/useDispatch.js';
 import { BoxBase, DockLayout, LayoutBase, LayoutData, PanelBase, TabGroup } from 'rc-dock';
 
-
 import React, { MutableRefObject, useEffect, useMemo } from 'react';
 import { EditorProps, ImperativeEditorRef } from "./editorTypes.js";
 import { FindDialog } from "@/components/dialogs/findDialog";
 import { MAIN_GRAPH_ID } from "@/constants";
+import { ErrorBoundary } from "react-error-boundary";
+import { ErrorBoundaryContent } from "@/components/ErrorBoundaryContent";
 
 const DockButton = (rest) => {
     return (
@@ -170,7 +171,11 @@ const layoutDataFactory = (props, ref): LayoutData => {
                                             group: 'popout',
                                             id: 'dropPanel',
                                             title: 'Nodes',
-                                            content: <DropPanel />,
+                                            content: (
+                                                <ErrorBoundary fallback={<ErrorBoundaryContent />}>
+                                                    <DropPanel />
+                                                </ErrorBoundary>
+                                            ),
                                             closable: true,
                                         },
                                     ],
@@ -193,7 +198,7 @@ const layoutDataFactory = (props, ref): LayoutData => {
 
                             size: 18,
                             mode: 'vertical',
-                            children:[
+                            children: [
                                 {
                                     id: 'graphs',
                                     size: 700,
@@ -207,17 +212,19 @@ const layoutDataFactory = (props, ref): LayoutData => {
                                             group: 'graph',
                                             title: 'Graph',
                                             content: (
-                                                <GraphEditor {...props} id={MAIN_GRAPH_ID} ref={ref} />
+                                                <ErrorBoundary fallback={<ErrorBoundaryContent />}>
+                                                    <GraphEditor {...props} id={MAIN_GRAPH_ID} ref={ref} />
+                                                </ErrorBoundary>
                                             ),
                                         },
                                     ],
                                 },
-                            
-                             
+
+
                             ]
 
                         },
-                        
+
                         {
                             size: 4,
                             mode: 'vertical',
@@ -231,7 +238,12 @@ const layoutDataFactory = (props, ref): LayoutData => {
                                             group: 'popout',
                                             id: 'input',
                                             title: 'Inputs',
-                                            content: <Inputsheet />,
+                                            content: (
+                                                <ErrorBoundary fallback={<ErrorBoundaryContent />}>
+                                                    <Inputsheet />
+                                                </ErrorBoundary>
+
+                                            ),
                                         }
                                     ],
                                 },
@@ -244,9 +256,13 @@ const layoutDataFactory = (props, ref): LayoutData => {
                                             group: 'popout',
                                             id: 'outputs',
                                             title: 'Outputs',
-                                            content: <OutputSheet />,
+                                            content: (
+                                                <ErrorBoundary fallback={<ErrorBoundaryContent />}>
+                                                    <OutputSheet />
+                                                </ErrorBoundary>
+                                            )
                                         }
-                                     
+
                                     ],
                                 },
                             ],
@@ -315,7 +331,7 @@ export const LayoutController = React.forwardRef<
                         style={{ flex: 1 }}
                         onLayoutChange={onLayoutChange}
                     />
-                    <FindDialog/>
+                    <FindDialog />
                 </Tooltip.Provider>
             </Stack>
         </ExternalLoaderProvider>

--- a/packages/graph-editor/src/registry/specifics.tsx
+++ b/packages/graph-editor/src/registry/specifics.tsx
@@ -13,6 +13,8 @@ import { ColorScale } from "@/components/preview/colorScale";
 import { ColorCompare } from "@/components/preview/colorCompare";
 import { MathExpression } from "@/components/preview/mathExpression";
 import { title as annotatedTitle } from "@/annotations";
+import { ErrorBoundary } from "react-error-boundary";
+import { ErrorBoundaryContent } from "@/components/ErrorBoundaryContent";
 
 const SubgraphExplorer = ({ node }) => {
 
@@ -28,7 +30,7 @@ const SubgraphExplorer = ({ node }) => {
         let oneShot = false;
         const innerGraph = node._innerGraph;
         const graphId = innerGraph.annotations['engine.id'];
-        const title = node.annotations[annotatedTitle] || innerGraph.annotations['engine.title'] || 'Subgraph' ;
+        const title = node.annotations[annotatedTitle] || innerGraph.annotations['engine.title'] || 'Subgraph';
         //Find the container
         const existing = dockerRef.current.find(graphId);
 
@@ -49,7 +51,9 @@ const SubgraphExplorer = ({ node }) => {
                 group: 'graph',
                 title,
                 content: (
-                    <GraphEditor ref={ref} id={graphId} />
+                    <ErrorBoundary fallback={<ErrorBoundaryContent />}>
+                        <GraphEditor ref={ref} id={graphId} />
+                    </ErrorBoundary>
                 ),
             };
 
@@ -96,7 +100,7 @@ const NumberPreview = observer(({ node }: { node: Node }) => {
     const shift = 10 ** precision;
     const number = Math.round(value * shift) / shift;
 
-    return <Box css={{backgroundColor: '$bgEmphasis', color: '$fgOnEmphasis', fontFamily: '$mono', fontSize: '64px', padding: '$5', textAlign: 'center'}}>{number}</Box>;
+    return <Box css={{ backgroundColor: '$bgEmphasis', color: '$fgOnEmphasis', fontFamily: '$mono', fontSize: '64px', padding: '$5', textAlign: 'center' }}>{number}</Box>;
 });
 
 export const defaultSpecifics = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23025,10 +23025,10 @@ react-element-to-jsx-string@^15.0.0:
     is-plain-object "5.0.0"
     react-is "18.1.0"
 
-react-error-boundary@4.0.11, react-error-boundary@^4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
-  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+react-error-boundary@4.0.13, react-error-boundary@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.13.tgz#80386b7b27b1131c5fbb7368b8c0d983354c7947"
+  integrity sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a new `ErrorBoundaryContent` component to handle error states and provide options to save the current graph state or reload the page.
- Integrated `ErrorBoundary` in key components (`DropPanel`, `GraphEditor`, `Inputsheet`, `OutputSheet`) within `layoutController` and `SubgraphExplorer`.
- Updated `react-error-boundary` dependency to version `4.0.13`.
- Added a changeset note for the enhancements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ErrorBoundaryContent.tsx</strong><dd><code>Add ErrorBoundaryContent component for error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/ErrorBoundaryContent.tsx
<li>Added a new <code>ErrorBoundaryContent</code> component to handle error states.<br> <li> Implemented functionality to save the current graph state as a JSON <br>file.<br> <li> Included UI elements like <code>Button</code> and <code>Text</code> for user interaction during <br>errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/315/files#diff-f70e66a0e526b150073a9cd6fdc87c0201b34e42676e57ea49e41f5678765ab0">+44/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>layoutController.tsx</strong><dd><code>Integrate ErrorBoundary in layoutController components</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/layoutController.tsx
<li>Wrapped key components (<code>DropPanel</code>, <code>GraphEditor</code>, <code>Inputsheet</code>, <br><code>OutputSheet</code>) in <code>ErrorBoundary</code>.<br> <li> Integrated <code>ErrorBoundaryContent</code> as the fallback component.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/315/files#diff-60d8069b739deeb69c0c06a98fabfccd34dca2ef65e06c4aa8d76603ca6e1af3">+27/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>specifics.tsx</strong><dd><code>Add ErrorBoundary to SubgraphExplorer component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/registry/specifics.tsx
<li>Wrapped <code>GraphEditor</code> in <code>ErrorBoundary</code> within <code>SubgraphExplorer</code>.<br> <li> Integrated <code>ErrorBoundaryContent</code> as the fallback component.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/315/files#diff-142ba4f93d6627f082c5b1f1d51439cb261ad7add750444e5730c9287f3cbc3c">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>angry-dolls-call.md</strong><dd><code>Add changeset for error boundaries enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/angry-dolls-call.md
<li>Added a changeset note for adding error boundaries to the graph editor <br>panels.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/315/files#diff-06df9db3b529b7191a9aacf2bfa863ea99fb8fe68728cc3e4eb58ca06a498a6f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update react-error-boundary dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/package.json
<li>Updated <code>react-error-boundary</code> dependency version from <code>4.0.11</code> to <code>4.0.13</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/315/files#diff-6ccba169f1b9d5e1313b2f1b6061c30c13d6c52c48c09055348963f1bff59d06">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

