### PR TITLE
Fix selection

### DIFF
--- a/.changeset/mighty-donuts-wait.md
+++ b/.changeset/mighty-donuts-wait.md
@@ -1,0 +1,8 @@
+---
+"@tokens-studio/graph-editor": minor
+---
+
+- Use ReactFlow selection state as source of truth
+- Elevate nodes on selection
+- Auto select nodes when added to the stage
+- Clear nodes selection when swithing graph tabs

--- a/packages/graph-editor/src/components/commandPalette/index.tsx
+++ b/packages/graph-editor/src/components/commandPalette/index.tsx
@@ -12,11 +12,16 @@ import { styled } from '@/lib/stitches';
 import { Search } from 'iconoir-react';
 import { observer } from 'mobx-react-lite';
 import { isActiveElementTextEditable } from '@/utils/isActiveElementTextEditable.js';
-import { useReactFlow } from 'reactflow';
+import { useReactFlow, Node as FlowNode } from 'reactflow';
+import { Node } from '@tokens-studio/graph-engine';
+import { useSelectAddedNodes } from '@/hooks/useSelectAddedNodes.js';
 
 export interface ICommandMenu {
   items: DropPanelStore;
-  handleSelectNewNodeType: (node: { type: string }) => void;
+  handleSelectNewNodeType: (node: { type: string }) => {
+    graphNode: Node,
+    flowNode: FlowNode
+  };
 }
 
 const CommandItem = observer(
@@ -81,12 +86,15 @@ const CommandMenu = ({
   const cursorPositionRef = React.useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const [selectedItem, setSelectedItem] = React.useState('input');
   const reactflow = useReactFlow();
+  const selectAddedNodes = useSelectAddedNodes();
 
   const handleSelectItem = (item) => {
-    handleSelectNewNodeType({
+    const newNode = handleSelectNewNodeType({
       position: reactflow.screenToFlowPosition(cursorPositionRef.current),
       ...item,
     });
+    selectAddedNodes([newNode.flowNode])
+
     dispatch.ui.setShowNodesCmdPalette(false);
   };
 

--- a/packages/graph-editor/src/components/commandPalette/index.tsx
+++ b/packages/graph-editor/src/components/commandPalette/index.tsx
@@ -15,13 +15,14 @@ import { isActiveElementTextEditable } from '@/utils/isActiveElementTextEditable
 import { useReactFlow, Node as FlowNode } from 'reactflow';
 import { Node } from '@tokens-studio/graph-engine';
 import { useSelectAddedNodes } from '@/hooks/useSelectAddedNodes.js';
+import { NodeRequest } from '@/editor/actions/createNode.js';
 
 export interface ICommandMenu {
   items: DropPanelStore;
-  handleSelectNewNodeType: (node: { type: string }) => {
+  handleSelectNewNodeType: (node: NodeRequest) => {
     graphNode: Node,
     flowNode: FlowNode
-  };
+  } | undefined;
 }
 
 const CommandItem = observer(

--- a/packages/graph-editor/src/components/commandPalette/index.tsx
+++ b/packages/graph-editor/src/components/commandPalette/index.tsx
@@ -94,7 +94,9 @@ const CommandMenu = ({
       position: reactflow.screenToFlowPosition(cursorPositionRef.current),
       ...item,
     });
-    selectAddedNodes([newNode.flowNode])
+    if (newNode) {
+      selectAddedNodes([newNode.flowNode])
+    }
 
     dispatch.ui.setShowNodesCmdPalette(false);
   };

--- a/packages/graph-editor/src/components/flow/wrapper/node.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/node.tsx
@@ -5,9 +5,7 @@ import {
   Text,
 } from '@tokens-studio/ui';
 import { styled } from '@stitches/react';
-import React, { useCallback, useMemo } from 'react';
-import GraphLib from '@dagrejs/graphlib';
-import { useDispatch } from '@/hooks/useDispatch.js';
+import React, { useMemo } from 'react';
 
 const CollapserContainer = styled('div', {});
 
@@ -59,8 +57,8 @@ const NodeWrapper = styled('div', {
   position: 'relative',
   borderRadius: '$medium',
   background: '$gray6',
-  flex:1,
-  display:'flex',
+  flex: 1,
+  display: 'flex',
   variants: {
     error: {
       true: {
@@ -75,12 +73,7 @@ const NodeWrapper = styled('div', {
 export const Node = (props: NodeProps) => {
   const { id, icon, title, subtitle, error, isAsync, children, controls, ...rest } =
     props;
-  const dispatch = useDispatch();
 
-
-  const onClick = useCallback(() => {
-    dispatch.graph.setCurrentNode(id);
-  }, [dispatch.graph, id]);
 
   return (
     <NodeWrapper error={Boolean(error)} className={error ? 'error' : ''}>
@@ -88,14 +81,13 @@ export const Node = (props: NodeProps) => {
         className='reactflow-draggable-handle'
         direction="column"
         gap={0}
-        css={{flex:1}}
-        onClick={onClick}
+        css={{ flex: 1 }}
         {...rest}
       >
         {title && (
           <>
             <Stack
-             
+
               direction="row"
               justify="between"
               align="center"

--- a/packages/graph-editor/src/components/flow/wrapper/node.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/node.tsx
@@ -55,6 +55,7 @@ export const Collapser = ({ children, collapsed }) => {
 
 const NodeWrapper = styled('div', {
   position: 'relative',
+  boxShadow: '$contextMenu',
   borderRadius: '$medium',
   background: '$gray6',
   flex: 1,

--- a/packages/graph-editor/src/editor/actions/createNode.tsx
+++ b/packages/graph-editor/src/editor/actions/createNode.tsx
@@ -1,8 +1,8 @@
 import { uiNodeType, xpos, ypos } from '@/annotations';
 import { INPUT, OUTPUT } from '@/ids';
 import { Dispatch } from '@/redux/store';
-import {  Node, Graph, NodeFactory } from '@tokens-studio/graph-engine';
-import { ReactFlowInstance } from 'reactflow';
+import { Node, Graph, NodeFactory } from '@tokens-studio/graph-engine';
+import { ReactFlowInstance, Node as ReactFlowNode } from 'reactflow';
 
 export type NodeRequest = {
   type: string;
@@ -75,7 +75,7 @@ export const createNode = ({
     node.annotations[xpos] = finalPos.x;
     node.annotations[ypos] = finalPos.y;
 
-    if (customUI[nodeRequest.type]){
+    if (customUI[nodeRequest.type]) {
       node.annotations[uiNodeType] = customUI[nodeRequest.type];
     }
 
@@ -92,15 +92,14 @@ export const createNode = ({
     //Update immediately
     graph.update(node.id);
 
-
     //Add the node to the react flow instance
     const reactFlowNode = {
       id: node.id,
-      dragHandle:'.reactflow-draggable-handle',
+      dragHandle: '.reactflow-draggable-handle',
       type: customUI[nodeRequest.type] || 'GenericNode',
       data: {},
       position: finalPos,
-    };
+    } as ReactFlowNode;
 
     dispatch.graph.appendLog({
       time: new Date(),
@@ -113,6 +112,7 @@ export const createNode = ({
     })
 
     reactFlowInstance.addNodes(reactFlowNode);
+
     return {
       graphNode: node,
       flowNode: reactFlowNode

--- a/packages/graph-editor/src/hooks/useSelectAddedNodes.tsx
+++ b/packages/graph-editor/src/hooks/useSelectAddedNodes.tsx
@@ -1,0 +1,25 @@
+import { Node, useReactFlow } from 'reactflow'
+
+export const useSelectAddedNodes = () => {
+  const reactFlowInstance = useReactFlow();
+
+  const selectAddedNodes = (newNodes: Node[]) => {
+    reactFlowInstance.setNodes((nds) => {
+      return [
+        ...nds.map((node) => {
+          node.selected = false;
+          return node;
+        }),
+        ...newNodes.map((flowNode) => {
+          flowNode.selected = true;
+          return flowNode;
+        }),
+
+      ]
+    }
+    );
+  }
+
+  return selectAddedNodes;
+
+}

--- a/packages/graph-editor/src/hooks/useSetCurrentNode.tsx
+++ b/packages/graph-editor/src/hooks/useSetCurrentNode.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useEffect } from "react";
+import { useOnSelectionChange, useReactFlow } from "reactflow";
+import { useDispatch } from ".";
+import { useSelector } from "react-redux";
+import { currentPanelIdSelector } from "..";
+
+export const useSetCurrentNode = () => {
+  const dispatch = useDispatch();
+  const { setNodes } = useReactFlow();
+  const currentPanel = useSelector(currentPanelIdSelector)
+
+  // deselect all nodes when the panel changes
+  useEffect(() => {
+    setNodes((nodes) => {
+      return nodes.map((node) => {
+        node.selected = false;
+        return node;
+      });
+    }
+    );
+    dispatch.graph.setCurrentNode('');
+  }, [currentPanel]);
+
+  // the passed handler has to be memoized, otherwise the hook will not work correctly
+  const onChange = useCallback(({ nodes, edges }) => {
+    const selectedIds = nodes.map((node) => node.id);
+    if (selectedIds.length === 1) {
+      dispatch.graph.setCurrentNode(selectedIds[0] || null);
+    }
+
+  }, [])
+
+  useOnSelectionChange({
+    onChange
+  });
+
+}


### PR DESCRIPTION
### **User description**
- Use ReactFlow selection state as source of truth
 as a result tab selection works, drag selection works. 
- Elevate nodes on selection
- Auto select nodes when added to the stage
- Clear nodes selection when swithing graph tabs


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Integrated `useSelectAddedNodes` hook to auto-select newly added nodes.
- Added `useSetCurrentNode` hook to manage current node based on selection changes.
- Modified `createNode` action to return both `graphNode` and `flowNode`.
- Enabled node elevation on selection in the graph editor.
- Removed unused `selectNode` action and dispatch logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Integrate node auto-selection on addition in command palette.</code></dd></summary>
<hr>

packages/graph-editor/src/components/commandPalette/index.tsx
<li>Added <code>useSelectAddedNodes</code> hook to auto-select newly added nodes.<br> <li> Modified <code>handleSelectNewNodeType</code> to return both <code>graphNode</code> and <br><code>flowNode</code>.<br> <li> Updated <code>handleSelectItem</code> to use <code>selectAddedNodes</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-38bd1232958c02a810167d383b9c76f92dcb17c18e775b5a02e47f2908191076">+11/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>node.tsx</strong><dd><code>Clean up node component by removing unused dispatch logic.</code></dd></summary>
<hr>

packages/graph-editor/src/components/flow/wrapper/node.tsx
<li>Removed unused <code>useDispatch</code> and <code>onClick</code> handler.<br> <li> Minor formatting adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-9f5931cfdd7cdc0c4c8706ac2c131b74522f9a22bac3026a903387ca828815e3">+5/-13</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>createNode.tsx</strong><dd><code>Return both graph and flow nodes in createNode action.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/actions/createNode.tsx
<li>Updated <code>createNode</code> to return both <code>graphNode</code> and <code>flowNode</code>.<br> <li> Minor formatting adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-6366425e8fff71bebc9c0eb169e6e2faf37e28ea1d4035d65c60058c1ba488b1">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graph.tsx</strong><dd><code>Enhance node selection and elevation in graph editor.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/graph.tsx
<li>Removed <code>selectNode</code> action.<br> <li> Integrated <code>useSetCurrentNode</code> and <code>useSelectAddedNodes</code> hooks.<br> <li> Enabled node elevation on selection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-0a5251be74b5e25cb4df55d09e1906b29f32d52ea95168b26c72ccfdd66d2c30">+15/-19</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useSelectAddedNodes.tsx</strong><dd><code>Add hook for auto-selecting newly added nodes.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/hooks/useSelectAddedNodes.tsx
- Added new hook to auto-select newly added nodes.



</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-e491a98c8bb945476f946f43afe06e79699c78a96f47df1111cadd9b1e1645ce">+25/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useSetCurrentNode.tsx</strong><dd><code>Add hook for setting current node on selection change.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/hooks/useSetCurrentNode.tsx
- Added new hook to set the current node based on selection changes.



</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-bbf086b0b9b5f9cb4698e6f4791eb05072bcd6f1f4d79c4bd4a10b86ddb1f041">+37/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mighty-donuts-wait.md</strong><dd><code>Add changeset for node selection enhancements.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/mighty-donuts-wait.md
<li>Documented changes for auto-selecting nodes and using ReactFlow <br>selection state.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/340/files#diff-2bbfb43342e6d11336c31586a34f8868d7d3894b528ff90d745902f436b15193">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

