### PR TITLE
fix width swatch in color compare node

### DIFF
--- a/.changeset/wet-peaches-hug.md
+++ b/.changeset/wet-peaches-hug.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fix the width of the color swatch on color compare node.

--- a/packages/graph-editor/src/components/preview/colorCompare.tsx
+++ b/packages/graph-editor/src/components/preview/colorCompare.tsx
@@ -24,7 +24,7 @@ export const ColorCompare = ({ colors }) => {
     {colors && (
         <Stack direction='row' gap={0}>
             {colors.map(color =>
-                <Box css={{display: 'grid', placeItems: 'center', minHeight: '100px', backgroundColor: color, padding: '$8'}}>
+                <Box css={{display: 'grid', placeItems: 'center', minHeight: '100px', backgroundColor: color, padding: '$8', width: '100%'}}>
                     <Text css={{fontFamily: '$mono', fontSize: 'xx-large', color: contrastingColor(color)}}>{color}</Text>
                 </Box>
             )}


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed the width of the color swatch in the `ColorCompare` component by adding `width: 100%` to the `Box` component.
- Added a changeset entry to document the fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>colorCompare.tsx</strong><dd><code>Fix width of color swatch in ColorCompare component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/preview/colorCompare.tsx
<li>Added <code>width: 100%</code> to the <code>Box</code> component to fix the swatch width issue.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/346/files#diff-b2dceb871d45b34af5974ed1e773475f2b620192384fd41d7746d627f666cd04">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wet-peaches-hug.md</strong><dd><code>Add changeset for color swatch width fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/wet-peaches-hug.md
- Added changeset entry for the color swatch width fix.



</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/346/files#diff-1b81077d63ac4a282e7b3c598ee25e05447d335052b7a7f20472aaeb43c5b865">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

