### PR TITLE
Check for common type when setting variadic type

### DIFF
--- a/.changeset/happy-ducks-relax.md
+++ b/.changeset/happy-ducks-relax.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-engine": minor
+---
+
+Set dynamic types for variadic inputs

--- a/packages/graph-engine/src/programmatic/input.ts
+++ b/packages/graph-engine/src/programmatic/input.ts
@@ -69,7 +69,8 @@ export class Input<T = any> extends Port<T> {
             return outputs[edge.sourceHandle].type
           });
 
-          if (sourceNodesOutputTypes.every(type => JSON.stringify(type) === JSON.stringify(sourceNodesOutputTypes[0]))) {
+          const firstNodeTypeStringValue = JSON.stringify(sourceNodesOutputTypes[0])
+          if (sourceNodesOutputTypes.every(type => JSON.stringify(type) === firstNodeTypeStringValue)) {
               this._dynamicType = { 
                 type: 'array',
                 items: sourceNodesOutputTypes[0]

--- a/packages/graph-engine/src/programmatic/input.ts
+++ b/packages/graph-engine/src/programmatic/input.ts
@@ -64,17 +64,18 @@ export class Input<T = any> extends Port<T> {
         // for variadic ports, we need to set the dynamic type depending on all the other connected types
         if (variadic && _dynamicType && JSON.stringify(_dynamicType) !== JSON.stringify(opts.type)) {          
           const graph = this.node.getGraph();
-          
-          const sourceNodesOutputs = this._edges.map(edge => graph.getNode(edge.source).outputs);
-          const sourceNodesOuputTypes = sourceNodesOutputs.map(output => output.value?.type);
+          const sourceNodesOutputTypes = this._edges.map(edge => {
+            const outputs = graph.getNode(edge.source).outputs;
+            return outputs[edge.sourceHandle].type
+          });
 
-          if (sourceNodesOuputTypes.every(type => JSON.stringify(type) === JSON.stringify(sourceNodesOuputTypes[0]))) {
+          if (sourceNodesOutputTypes.every(type => JSON.stringify(type) === JSON.stringify(sourceNodesOutputTypes[0]))) {
               this._dynamicType = { 
                 type: 'array',
-                items: sourceNodesOuputTypes[0]
+                items: sourceNodesOutputTypes[0]
               }
           } else {
-            this._dynamicType = AnyArraySchema;
+            this._dynamicType = undefined;
           }
 
         } else {

--- a/packages/graph-engine/src/programmatic/input.ts
+++ b/packages/graph-engine/src/programmatic/input.ts
@@ -64,11 +64,11 @@ export class Input<T = any> extends Port<T> {
         // for variadic ports, we need to set the dynamic type depending on all the other connected types
         if (variadic && _dynamicType && JSON.stringify(_dynamicType) !== JSON.stringify(opts.type)) {          
           const graph = this.node.getGraph();
-          const inEdges = graph.inEdges(this.node.id);
-          const sourceNodesOutputs = inEdges.map(edge => edge.source).map(id => graph.getNode(id).outputs);
+          
+          const sourceNodesOutputs = this._edges.map(edge => graph.getNode(edge.source).outputs);
           const sourceNodesOuputTypes = sourceNodesOutputs.map(output => output.value?.type);
 
-          if (sourceNodesOuputTypes.every(type => type?.$id === sourceNodesOuputTypes[0].$id)) {
+          if (sourceNodesOuputTypes.every(type => JSON.stringify(type) === JSON.stringify(sourceNodesOuputTypes[0]))) {
               this._dynamicType = { 
                 type: 'array',
                 items: sourceNodesOuputTypes[0]


### PR DESCRIPTION
### **User description**
https://github.com/tokens-studio/graph-engine/assets/21245398/fad9c80f-673e-4f89-9a78-957b144d77c7


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `Input` class to handle variadic ports more intelligently.
- Added logic to check for a common type among connected nodes' output types.
- Set `_dynamicType` to `AnyArraySchema` if connected nodes have differing types.
- Imported `AnyArraySchema` to support the new type handling logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>input.ts</strong><dd><code>Enhanced type handling for variadic ports in Input class</code>&nbsp; </dd></summary>
<hr>

packages/graph-engine/src/programmatic/input.ts
<li>Imported <code>AnyArraySchema</code> from <code>../schemas/index.js</code>.<br> <li> Enhanced type checking and setting for variadic ports.<br> <li> Added logic to determine common type among connected nodes.<br> <li> Fallback to <code>AnyArraySchema</code> if types differ.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/354/files#diff-8735da8ac584fbf39a323c4124f23756b80ae4e9aaa74a28ea355b3f8a67af53">+22/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

