### PR TITLE
fix center alignment on node handles

### DIFF
--- a/.changeset/dull-games-hunt.md
+++ b/.changeset/dull-games-hunt.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fix the center alignment of handles on a node

--- a/packages/graph-editor/src/components/flow/handles.tsx
+++ b/packages/graph-editor/src/components/flow/handles.tsx
@@ -47,7 +47,6 @@ export const HandleContainer = ({
         direction="column"
         gap={2}
         css={{ flexBasis: full ? '100%' : '50%', position: 'relative', textAlign: type === 'source' ? 'right' : 'left', minWidth: isSmall ? 'auto' : '250px' }}
-        justify='center'
         className={className}
       >
         {children}


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation


___

### **Description**
- Removed `justify='center'` from the `Stack` component in `handles.tsx` to fix the center alignment issue of node handles.
- Added a changeset entry to document the alignment fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handles.tsx</strong><dd><code>Fix center alignment issue in node handles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/handles.tsx
<li>Removed <code>justify='center'</code> from <code>Stack</code> component to fix alignment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/366/files#diff-8894a9f9739633943a3bb8589e433b347119e6d70213e1104139d05c634b1b53">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dull-games-hunt.md</strong><dd><code>Document alignment fix in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/dull-games-hunt.md
- Added a changeset entry to document the alignment fix.



</details>
    

  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/366/files#diff-ba49318796d940182c513c17cab2cfd5af7de15218028bb7d3c44cf85fdb5aa5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

