### PR TITLE
Added Snap node

### DIFF
--- a/packages/graph-engine/src/nodes/math/index.ts
+++ b/packages/graph-engine/src/nodes/math/index.ts
@@ -22,6 +22,7 @@ import random from './random.js';
 import rangeMapping from './rangeMapping.js';
 import round from './round.js';
 import sin from './sin.js';
+import snap from './snap.js';
 import sqrt from './sqrt.js';
 import subtract from './subtract.js';
 import subtractVariadic from './subtractVariadic.js';
@@ -52,6 +53,7 @@ export const nodes = [
 	random,
 	round,
 	sin,
+	snap,
 	subtract,
 	subtractVariadic,
 	tan,

--- a/packages/graph-engine/src/nodes/math/snap.ts
+++ b/packages/graph-engine/src/nodes/math/snap.ts
@@ -1,0 +1,74 @@
+import { INodeDefinition, ToInput, ToOutput } from '../../index.js';
+import { Node } from '../../programmatic/node.js';
+import { NumberSchema, StringSchema } from '../../schemas/index.js';
+import { ValueSnapMethod } from '../../types/index.js';
+
+export default class NodeDefinition extends Node {
+	static title = 'Snap';
+	static type = 'studio.tokens.math.snap';
+	static description =
+		'Snap node rounds the input value to the nearest multiple of the increment, offset by the base.';
+
+	declare inputs: ToInput<{
+		value: number;
+		method: ValueSnapMethod;
+		base: number;
+		increment: number;
+	}>;
+	declare outputs: ToOutput<{
+		value: number;
+	}>;
+
+	constructor(props: INodeDefinition) {
+		super(props);
+		this.addInput('value', {
+			type: {
+				...NumberSchema,
+				default: 3
+			}
+		});
+		this.addInput('method', {
+			type: {
+				...StringSchema,
+				enum: Object.values(ValueSnapMethod),
+				default: ValueSnapMethod.Round
+			}
+		});
+		this.addInput('base', {
+			type: {
+				...NumberSchema,
+				default: 0
+			}
+		});
+		this.addInput('increment', {
+			type: {
+				...NumberSchema,
+				default: 2
+			}
+		});
+		this.addOutput('value', {
+			type: NumberSchema
+		});
+	}
+
+	execute(): void | Promise<void> {
+		const { value, method, base, increment } = this.getAllInputs();
+
+		let snap: (x: number) => number;
+
+		switch (method) {
+			case ValueSnapMethod.Floor:
+				snap = Math.floor;
+				break;
+			case ValueSnapMethod.Round:
+			default:
+				snap = Math.round;
+				break;
+			case ValueSnapMethod.Ceil:
+				snap = Math.ceil;
+				break;
+		}
+
+		this.outputs.value.set(base + increment * snap((value - base) / increment));
+	}
+}

--- a/packages/graph-engine/src/types.ts
+++ b/packages/graph-engine/src/types.ts
@@ -1,4 +1,4 @@
-import { ContrastAlgorithm } from './types/index.js';
+import { ContrastAlgorithm, ValueSnapMethod } from './types/index.js';
 import type { Graph } from './graph/graph.js';
 import type { Node } from './programmatic/node.js';
 
@@ -72,3 +72,5 @@ export type GradientStop = {
 };
 
 export type ContrastAlgorithmType = keyof typeof ContrastAlgorithm;
+
+export type ValueSnapMethodType = keyof typeof ValueSnapMethod;

--- a/packages/graph-engine/src/types/index.ts
+++ b/packages/graph-engine/src/types/index.ts
@@ -6,3 +6,9 @@ export enum ContrastAlgorithm {
 	Lstar = 'Lstar',
 	DeltaPhi = 'DeltaPhi'
 }
+
+export enum ValueSnapMethod {
+	Floor = 'Floor',
+	Round = 'Round',
+	Ceil = 'Ceil'
+}

--- a/packages/graph-engine/tests/suites/nodes/math/snap.test.ts
+++ b/packages/graph-engine/tests/suites/nodes/math/snap.test.ts
@@ -1,0 +1,39 @@
+import { Graph } from '../../../../src/graph/graph.js';
+import { ValueSnapMethod } from '../../../../src/types/index.js';
+import { describe, expect, test } from 'vitest';
+import Node from '../../../../src/nodes/math/snap.js';
+
+describe('math/snap', () => {
+	test('floors value to increment', async () => {
+		const graph = new Graph();
+		const node = new Node({ graph });
+		node.inputs.value.setValue(17.3);
+		node.inputs.method.setValue(ValueSnapMethod.Floor);
+		node.inputs.base.setValue(5);
+		node.inputs.increment.setValue(10);
+		await node.execute();
+		expect(node.outputs.value.value).to.equal(15);
+	});
+
+	test('rounds value to increment', async () => {
+		const graph = new Graph();
+		const node = new Node({ graph });
+		node.inputs.value.setValue(17.3);
+		node.inputs.method.setValue(ValueSnapMethod.Round);
+		node.inputs.base.setValue(5);
+		node.inputs.increment.setValue(10);
+		await node.execute();
+		expect(node.outputs.value.value).to.equal(15);
+	});
+
+	test('ceils value to increment', async () => {
+		const graph = new Graph();
+		const node = new Node({ graph });
+		node.inputs.value.setValue(17.3);
+		node.inputs.method.setValue(ValueSnapMethod.Ceil);
+		node.inputs.base.setValue(5);
+		node.inputs.increment.setValue(10);
+		await node.execute();
+		expect(node.outputs.value.value).to.equal(25);
+	});
+});


### PR DESCRIPTION
# Description

* this node takes an input value and then snaps it to the nearest increment, offset by the base
* the rounding method can be Floor/Round/Ceil.

Fixes #397

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to test this

# Screenshots or video (if necessary):

