### PR TITLE
Output precision in Snap node now follows input precision

### DIFF
--- a/packages/graph-engine/src/utils/precision.ts
+++ b/packages/graph-engine/src/utils/precision.ts
@@ -2,3 +2,7 @@ export function setToPrecision(value: number, precision: number) {
 	const shift = 10 ** precision;
 	return Math.round(value * shift) / shift;
 }
+
+export function getDecimalCount(value: number) {
+	return value == 0 ? 0 : Math.max(0, -Math.floor(Math.log10(Math.abs(value))));
+}

--- a/packages/graph-engine/tests/suites/nodes/math/snap.test.ts
+++ b/packages/graph-engine/tests/suites/nodes/math/snap.test.ts
@@ -47,5 +47,4 @@ describe('math/snap', () => {
 		await node.execute();
 		expect(node.outputs.snapped.value).to.equal(1.45);
 	});
-
 });

--- a/packages/graph-engine/tests/suites/nodes/math/snap.test.ts
+++ b/packages/graph-engine/tests/suites/nodes/math/snap.test.ts
@@ -8,32 +8,44 @@ describe('math/snap', () => {
 		const graph = new Graph();
 		const node = new Node({ graph });
 		node.inputs.value.setValue(17.3);
-		node.inputs.method.setValue(ValueSnapMethod.Floor);
-		node.inputs.base.setValue(5);
 		node.inputs.increment.setValue(10);
+		node.inputs.base.setValue(5);
+		node.inputs.method.setValue(ValueSnapMethod.Floor);
 		await node.execute();
-		expect(node.outputs.value.value).to.equal(15);
+		expect(node.outputs.snapped.value).to.equal(15);
 	});
 
 	test('rounds value to increment', async () => {
 		const graph = new Graph();
 		const node = new Node({ graph });
 		node.inputs.value.setValue(17.3);
-		node.inputs.method.setValue(ValueSnapMethod.Round);
-		node.inputs.base.setValue(5);
 		node.inputs.increment.setValue(10);
+		node.inputs.base.setValue(5);
+		node.inputs.method.setValue(ValueSnapMethod.Round);
 		await node.execute();
-		expect(node.outputs.value.value).to.equal(15);
+		expect(node.outputs.snapped.value).to.equal(15);
 	});
 
 	test('ceils value to increment', async () => {
 		const graph = new Graph();
 		const node = new Node({ graph });
 		node.inputs.value.setValue(17.3);
-		node.inputs.method.setValue(ValueSnapMethod.Ceil);
-		node.inputs.base.setValue(5);
 		node.inputs.increment.setValue(10);
+		node.inputs.base.setValue(5);
+		node.inputs.method.setValue(ValueSnapMethod.Ceil);
 		await node.execute();
-		expect(node.outputs.value.value).to.equal(25);
+		expect(node.outputs.snapped.value).to.equal(25);
 	});
+
+	test('rounds value with specific precision', async () => {
+		const graph = new Graph();
+		const node = new Node({ graph });
+		node.inputs.value.setValue(1.46);
+		node.inputs.increment.setValue(0.05);
+		node.inputs.base.setValue(0);
+		node.inputs.method.setValue(ValueSnapMethod.Round);
+		await node.execute();
+		expect(node.outputs.snapped.value).to.equal(1.45);
+	});
+
 });


### PR DESCRIPTION
# Description

* Output precision is now taken as the maximum of all the relevant input values' precisions.
* Renamed output port to "snapped".
* Reordered the inputs to make more sense.
* Added test for specific precision.
* Added `getDecimalCount()` to utils to also be used elsewhere.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![image](https://github.com/user-attachments/assets/eb7ef186-d984-436a-9a05-86d3ec0cbd5c)
