### PR TITLE
Index Array node now accepts negative index values

### DIFF
--- a/.changeset/great-clocks-help.md
+++ b/.changeset/great-clocks-help.md
@@ -1,0 +1,6 @@
+---
+"@tokens-studio/graph-engine": minor
+"@tokens-studio/graph-engine-ui": minor
+---
+
+Index Array node now accepts negative index values

--- a/packages/graph-engine/src/nodes/array/indexArray.ts
+++ b/packages/graph-engine/src/nodes/array/indexArray.ts
@@ -50,7 +50,7 @@ export default class NodeDefinition<T> extends Node {
 		const array = this.inputs.array;
 		const { index } = this.getAllInputs();
 		//Get the value
-		const calculated = array.value[index];
+		const calculated = array.value.at(index)!;
 		//Extract the type
 		//We assume that the array has a single defined item
 

--- a/packages/graph-engine/tests/suites/nodes/array/indexArray.test.ts
+++ b/packages/graph-engine/tests/suites/nodes/array/indexArray.test.ts
@@ -16,6 +16,19 @@ describe('array/indexArray', () => {
 		expect(output).to.eql(1);
 	});
 
+	test('returns value at negative index', async () => {
+		const graph = new Graph();
+		const node = new Node({ graph });
+
+		node.inputs.array.setValue([11, 22, 33, 44, 55]);
+		node.inputs.index.setValue(-2);
+
+		await node.execute();
+
+		const output = node.outputs.value.value;
+		expect(output).to.eql(44);
+	});
+
 	test('returns undefined when out of bounds', async () => {
 		const graph = new Graph();
 		const node = new Node({ graph });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,6 +40,7 @@
     "@tokens-studio/graph-engine-nodes-design-tokens": "*",
     "@tokens-studio/graph-engine-nodes-figma": "*",
     "@tokens-studio/graph-engine-nodes-image": "*",
+    "@tokens-studio/icons": "0.1.3",
     "@tokens-studio/tokens": "0.0.24",
     "@tokens-studio/ui": "0.6.9",
     "@ts-rest/core": "3.51.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,6 +6539,11 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
   integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
 
+"@tokens-studio/icons@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@tokens-studio/icons/-/icons-0.1.3.tgz#043b3ebf1de8f4a59e2e05e461fa6b966c30d57c"
+  integrity sha512-cXQLPlPKsOJINdh84k2WDeEzfoq3dn9hzQrqiQfNLpA306V7lXXL0kzpVzEBhRFdLVLo+gTEdGQ4c+I3tQu1VA==
+
 "@tokens-studio/sd-transforms@^0.15.2":
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/@tokens-studio/sd-transforms/-/sd-transforms-0.15.2.tgz#2cd374b89a1167d66a9c29c2779623103221fac7"


### PR DESCRIPTION
# Description

* Index Array node now accepts negative index values, analogous to `[].at()`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![image](https://github.com/user-attachments/assets/fd03ea9b-fa29-4ea0-846a-7a7c6e5377f6)
