### PR TITLE
added back strokes to node edges

### DIFF
--- a/.changeset/fair-pears-share.md
+++ b/.changeset/fair-pears-share.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+node edges now have background-colored outlines for visual clarity at edge intersections

--- a/packages/graph-editor/src/components/flow/edges/edge.tsx
+++ b/packages/graph-editor/src/components/flow/edges/edge.tsx
@@ -84,6 +84,7 @@ export default function CustomEdge({
 
   return (
     <>
+      <path className="react-flow__edge-path-back" d={edgePath} />
       <path
         id={id}
         className="react-flow__edge-path"

--- a/packages/graph-editor/src/css/reactflow.css
+++ b/packages/graph-editor/src/css/reactflow.css
@@ -79,6 +79,12 @@
     stroke-opacity: 0.5;
 
 }
+.react-flow__edge-path-back
+{
+    stroke-width: 8px !important;
+    stroke: var(--colors-graphBg) !important;
+    fill: none;
+}
 .react-flow__edge-path,
 .react-flow__connection-path {
     stroke-width: 4px !important;


### PR DESCRIPTION
# Description

* node edges now have background-colored outlines for a bit of visual clarity at edge intersections

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![image](https://github.com/user-attachments/assets/5765a3fd-fb04-4bdb-a2e5-3fa1bbca951f)

![image](https://github.com/user-attachments/assets/a0d9f4a6-07a6-4f63-997c-489b71226538)
![image](https://github.com/user-attachments/assets/43b771a1-63b3-4868-b4cc-722435e8fe14)
![image](https://github.com/user-attachments/assets/3cad7650-8f29-492b-bb72-74f97ca03d27)


