### PR TITLE
Fix port visibility

### DIFF
--- a/.changeset/cold-teachers-shout.md
+++ b/.changeset/cold-teachers-shout.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fix bug with visibility on ports

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -146,7 +146,7 @@ export const PortArray = observer(({ ports, hideNames }: IPortArray) => {
   return (
     <>
       {entries
-        .filter((x) => x.visible || x.isConnected)
+        .filter((x) => x.visible != false || x.isConnected)
         .map((input) => (
           <InputHandle port={input} hideName={hideNames} />
         ))}


### PR DESCRIPTION
Fixes a bug with port visibility. The graph engine only stores visibility if explicitly set to true when serializing. This means that we should check that the visiblity is explicitly equal to false, not falsey