### PR TITLE
added discard/save dialog & clear current graph when loading new graph

### DIFF
--- a/.changeset/metal-jokes-jam.md
+++ b/.changeset/metal-jokes-jam.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Current graph is now cleared when loading a new graph, with a dialog option to save

--- a/packages/graph-editor/src/components/toolbar/buttons/upload.tsx
+++ b/packages/graph-editor/src/components/toolbar/buttons/upload.tsx
@@ -1,40 +1,89 @@
-import { IconButton, Tooltip } from '@tokens-studio/ui';
+import {
+  Button,
+  Dialog,
+  IconButton,
+  Stack,
+  Text,
+  Tooltip,
+} from '@tokens-studio/ui';
+import { Graph } from '@tokens-studio/graph-engine';
 import { ImperativeEditorRef } from '@/editor/editorTypes.js';
 import { mainGraphSelector } from '@/redux/selectors/graph.js';
+import { saveGraph } from '@/utils/saveGraph.js';
+import { title } from '@/annotations/index.js';
+import { useReactFlow } from 'reactflow';
 import { useSelector } from 'react-redux';
-import React from 'react';
+import React, { useState } from 'react';
 import Upload from '@tokens-studio/icons/Upload.js';
+import loadGraph from '@/utils/loadGraph.js';
 
 export const UploadToolbarButton = () => {
+  const reactFlowInstance = useReactFlow();
   const mainGraph = useSelector(mainGraphSelector);
   const graphRef = mainGraph?.ref as ImperativeEditorRef | undefined;
+  const graph = mainGraph?.graph as Graph;
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const onUpload = () => {
+  const handleUploadClick = () => {
+    const isCurrentGraphEmpty =
+      !graph?.nodes || Object.keys(graph.nodes).length === 0;
+
+    if (!isCurrentGraphEmpty) {
+      setIsDialogOpen(true);
+    } else {
+      loadGraph(graphRef, graph, reactFlowInstance);
+    }
+  };
+
+  const onSave = async () => {
     if (!graphRef) return;
+    await saveGraph(
+      graphRef,
+      graph,
+      (graph.annotations[title] || 'graph').toLowerCase().replace(/\s+/g, '-'),
+    );
+    setIsDialogOpen(false);
+    loadGraph(graphRef, graph, reactFlowInstance);
+  };
 
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.json';
-    //@ts-expect-error
-    input.onchange = (e: HTMLInputElement) => {
-      //@ts-expect-error
-      const file = e.target.files[0];
-      if (!file) return;
-      const reader = new FileReader();
-      reader.onload = (e: ProgressEvent<FileReader>) => {
-        const text = e.target?.result as string;
-        const data = JSON.parse(text);
-
-        graphRef.loadRaw(data);
-      };
-      reader.readAsText(file);
-    };
-    input.click();
+  const onDiscard = () => {
+    setIsDialogOpen(false);
+    loadGraph(graphRef, graph, reactFlowInstance);
   };
 
   return (
-    <Tooltip label="Upload" side="bottom">
-      <IconButton emphasis="low" onClick={onUpload} icon={<Upload />} />
-    </Tooltip>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <Dialog.Trigger asChild>
+        <Tooltip label="Upload" side="bottom">
+          <IconButton
+            emphasis="low"
+            icon={<Upload />}
+            onClick={handleUploadClick}
+          />
+        </Tooltip>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content>
+          <Stack direction="column" gap={4}>
+            <Dialog.Title>Save Current Graph?</Dialog.Title>
+            <Text>
+              Do you want to save the current graph before uploading a new one?
+            </Text>
+            <Stack direction="row" gap={2} justify="end">
+              <Dialog.Close asChild>
+                <Button emphasis="low" onClick={onDiscard}>
+                  Discard
+                </Button>
+              </Dialog.Close>
+              <Button emphasis="high" onClick={onSave}>
+                Save
+              </Button>
+            </Stack>
+          </Stack>
+          <Dialog.CloseButton />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
   );
 };

--- a/packages/graph-editor/src/utils/loadGraph.ts
+++ b/packages/graph-editor/src/utils/loadGraph.ts
@@ -1,0 +1,34 @@
+import { Graph } from '@tokens-studio/graph-engine';
+import { ImperativeEditorRef } from '@/editor/editorTypes.js';
+import { ReactFlowInstance } from 'reactflow';
+import { clear } from '@/editor/actions/clear.js';
+
+export default function loadGraph(
+  graphRef: ImperativeEditorRef | undefined,
+  graph: Graph,
+  reactFlowInstance: ReactFlowInstance,
+) {
+  if (!graphRef) return;
+
+  // always clear the graph before loading a new one,
+  // the user already had the choice to save it
+  clear(reactFlowInstance, graph);
+
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json';
+  //@ts-expect-error
+  input.onchange = (e: HTMLInputElement) => {
+    //@ts-expect-error
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e: ProgressEvent<FileReader>) => {
+      const text = e.target?.result as string;
+      const data = JSON.parse(text);
+      graphRef.loadRaw(data);
+    };
+    reader.readAsText(file);
+  };
+  input.click();
+}

--- a/packages/graph-editor/src/utils/saveGraph.ts
+++ b/packages/graph-editor/src/utils/saveGraph.ts
@@ -1,0 +1,24 @@
+import { Graph } from '@tokens-studio/graph-engine';
+import { ImperativeEditorRef } from '@/editor/editorTypes.js';
+
+export function saveGraph(
+  graphRef: ImperativeEditorRef,
+  graph: Graph,
+  filename: string,
+) {
+  const saved = graphRef.save();
+
+  const blob = new Blob([JSON.stringify(saved)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+
+  link.download = filename + '.json';
+  document.body.appendChild(link);
+
+  link.click();
+
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
# Description

* Now when you try to upload a graph, if there are any nodes in the current graph it will ask you if you want to discard or save. 
* I took the graph's name and made it lowercase and replaced the spaces with hyphens for the name, so currently graphs are downloaded as 'untitled-graph.json'.
*  Maybe we should ask the user to pick a file name when saving?

Solves #618

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to test this

Create some nodes, then try to load a graph.

# Video

![2bf2542d-5d76-4176-b39a-98214c0e63e3](https://github.com/user-attachments/assets/9246eb92-6a19-4161-8d58-26b7010501ae)
