### PR TITLE
Fixed not being able to drag nodes at same Y position as the toolbar

### DIFF
--- a/.changeset/proud-balloons-remember.md
+++ b/.changeset/proud-balloons-remember.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fixed not being able to drag nodes at the same vertical position as the toolbar

--- a/packages/graph-editor/src/components/toolbar/toolbar.module.css
+++ b/packages/graph-editor/src/components/toolbar/toolbar.module.css
@@ -8,6 +8,7 @@
   background-color: var(--color-neutral-canvas-default-bg);
   color: var(--color-neutral-canvas-subtle-fg-default);
   box-shadow: 0 2px 10px var(--color-neutral-800);
+  pointer-events: auto;
 }
 
 .separator {

--- a/packages/graph-editor/src/components/toolbar/toolbar.module.css
+++ b/packages/graph-editor/src/components/toolbar/toolbar.module.css
@@ -11,6 +11,17 @@
   pointer-events: auto;
 }
 
+.wrapper {
+  position: absolute;
+  top: var(--size-250);
+  left: 0;
+  right: 0;
+  display: grid;
+  place-items: center;
+  z-index: 99;
+  pointer-events: none;
+}
+
 .separator {
   width: 1px;
   background-color: var(--color-neutral-stroke-subtle);

--- a/packages/graph-editor/src/editor/graph.tsx
+++ b/packages/graph-editor/src/editor/graph.tsx
@@ -821,6 +821,7 @@ export const EditorApp = React.forwardRef<
                   display: 'grid',
                   placeItems: 'center',
                   zIndex: '99',
+                  pointerEvents: 'none',
                 }}
               >
                 <GraphToolbar />

--- a/packages/graph-editor/src/editor/graph.tsx
+++ b/packages/graph-editor/src/editor/graph.tsx
@@ -36,6 +36,7 @@ import React, {
   useState,
 } from 'react';
 import ReactFlow from 'reactflow';
+import toolbarStyles from '../components/toolbar/toolbar.module.css';
 
 import groupNode from '../components/flow/nodes/groupNode.js';
 import noteNode from '../components/flow/nodes/noteNode.js';
@@ -812,18 +813,7 @@ export const EditorApp = React.forwardRef<
                   handleSelectNewNodeType={handleSelectNewNodeType}
                 />
               )}
-              <div
-                style={{
-                  position: 'absolute',
-                  top: 'var(--size-250)',
-                  left: 0,
-                  right: 0,
-                  display: 'grid',
-                  placeItems: 'center',
-                  zIndex: '99',
-                  pointerEvents: 'none',
-                }}
-              >
+              <div className={toolbarStyles.wrapper}>
                 <GraphToolbar />
               </div>
               {props.children}


### PR DESCRIPTION
### **User description**
# Description

* Fixed not being able to drag nodes at same Y position as the toolbar

Fixes #617

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots or video (if necessary):

![a4764c1b-3704-4b8a-8546-2cb2237b412b](https://github.com/user-attachments/assets/4ffb0306-7b07-4857-a7b2-2fa24b012fe3)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed issue preventing node dragging behind toolbar.

- Added `pointerEvents: none` to toolbar container style.

- Ensured toolbar retains interactive pointer events.

- Added changeset entry for the fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graph.tsx</strong><dd><code>Adjust toolbar container to allow interactions behind</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/graph.tsx

<li>Added <code>pointerEvents: none</code> to toolbar container style.<br> <li> Ensured toolbar does not block interactions behind it.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/636/files#diff-0a5251be74b5e25cb4df55d09e1906b29f32d52ea95168b26c72ccfdd66d2c30">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>toolbar.module.css</strong><dd><code>Maintain toolbar interactivity with pointer-events adjustment</code></dd></summary>
<hr>

packages/graph-editor/src/components/toolbar/toolbar.module.css

<li>Set <code>pointer-events: auto</code> for toolbar itself.<br> <li> Ensured toolbar remains interactive while container is transparent.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/636/files#diff-f8248b51f7076fa9fdf681e01f174a39a71e48597373a1dd451c8dab7ef32c5f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proud-balloons-remember.md</strong><dd><code>Add changeset entry for toolbar drag fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/proud-balloons-remember.md

<li>Added changeset entry describing the bug fix.<br> <li> Documented fix for dragging nodes behind toolbar.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/636/files#diff-cd671bff7474fb25c56d05b408fd3b24a40279be54da2a6ef63ddb20008cee34">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information