### PR TITLE
fixed layout of handle names and live types

### DIFF
--- a/.changeset/serious-poems-burn.md
+++ b/.changeset/serious-poems-burn.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fixed layout of handle names and live types

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: yarn run test
 
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-artifacts

--- a/packages/graph-editor/src/components/flow/handles.module.css
+++ b/packages/graph-editor/src/components/flow/handles.module.css
@@ -3,12 +3,18 @@
   display: flex;
   align-items: center;
   padding: var(--component-spacing-2xs) var(--component-spacing-md);
+  margin-bottom: var(--component-spacing-xs);
+
+  &:not(:has(.handleText, span)) {
+    margin-bottom: var(--component-spacing-lg);
+  }
 
   &.collapsed {
     height: 0;
     overflow: hidden;
     position: absolute;
     top: 0;
+    margin-bottom: 0;
   }
 
   &.isAnchor {
@@ -34,7 +40,7 @@
 
 .handleHolder .rawHandle {
   --handle-border-width: var(--component-border-width-lg);
-  --handle-core-size: var(--size-50);
+  --handle-core-size: var(--size-75);
 
   background-color: var(--colors-graphBg);
   position: absolute;

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.module.css
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.module.css
@@ -5,10 +5,10 @@
 
 .inlineTypeLabel {
   position: absolute;
-  background: var(--color-neutral-surface-default-idle-bg);
+  background: rgba(from var(--color-neutral-surface-default-idle-bg) r g b / 0.65);
   color: var(--color-neutral-surface-default-idle-fg-default);
-  padding: var(--component-spacing-2xs);
-  font: var(--font-code-xs);
+  padding: var(--component-spacing-xs) var(--component-spacing-sm) var(--component-spacing-2xs) var(--component-spacing-sm);
+  font: var(--font-code-sm);
   border-radius: var(--component-radii-sm);
   text-transform: uppercase;
 
@@ -21,7 +21,10 @@
   }
 }
 
-
+:global(.ts-theme-dark) .inlineTypeLabel {
+    background: rgba(from var(--color-neutral-surface-default-idle-bg) r g b / 0.8);
+    font-weight: 800;
+}
 
 .colorSwatch {
   width: 16px;

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.module.css
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.module.css
@@ -21,11 +21,6 @@
   }
 }
 
-:global(.ts-theme-dark) .inlineTypeLabel {
-    background: rgba(from var(--color-neutral-surface-default-idle-bg) r g b / 0.8);
-    font-weight: 800;
-}
-
 .colorSwatch {
   width: 16px;
   height: 16px;

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -395,7 +395,7 @@ const InputHandle = observer(
           >
             <span
               style={{
-                font: 'var(--font-code-sm)',
+                font: 'var(--font-code-lg)',
                 color: 'var(--color-neutral-1500)',
               }}
             >


### PR DESCRIPTION
### **User description**
# Description

* restyled handle names and live types
* nameless ports no longer collapse into each other
* special handling in CSS for live types in dark mode (should probably be done in DS)

Fixes #638

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Video

![f041bf83-8e8c-49c6-8ab8-8c703a1cebed](https://github.com/user-attachments/assets/6972f743-309d-4393-b63a-00e6c919f3b6)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Adjusted font size for handle names for better readability.

- Improved CSS styling for handle holders and live types.
  - Added conditional margin adjustments for nameless ports.
  - Enhanced dark mode styling for live type labels.

- Updated inline type label styles for better visibility.

- Increased handle core size for better usability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodeV2.tsx</strong><dd><code>Adjusted font size for handle names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx

- Updated font size for handle names to `var(--font-code-lg)`.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/640/files#diff-22c64f79290285f9b5524bf34746fe5aba1d1ef1100277adfd1fd2403621c07d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>handles.module.css</strong><dd><code>Enhanced handle holder and core styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/handles.module.css

<li>Added margin adjustments for nameless ports.<br> <li> Increased handle core size to <code>var(--size-75)</code>.<br> <li> Improved CSS for collapsed handle holders.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/640/files#diff-549392e0d4516a50dc42d029eeffc71c01a6602a6e92f4ffa9973f08547f0ac0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nodeV2.module.css</strong><dd><code>Improved inline type label styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/wrapper/nodeV2.module.css

<li>Updated background and padding for inline type labels.<br> <li> Added dark mode-specific styles for live type labels.<br> <li> Adjusted font size and weight for better visibility.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/640/files#diff-808a6d422f627cf565368ba18abed7d7f148b78723aae6d86aaa2bb7cf037042">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information