### PR TITLE
fixed not being able to click out of command palette

### DIFF
--- a/.changeset/tricky-onions-care.md
+++ b/.changeset/tricky-onions-care.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fixed not being able to click out of Command Palette

--- a/packages/graph-editor/src/components/commandPalette/index.tsx
+++ b/packages/graph-editor/src/components/commandPalette/index.tsx
@@ -83,6 +83,7 @@ const CommandMenuGroup = observer(
 const CommandMenu = ({ items, handleSelectNewNodeType }: ICommandMenu) => {
   const showNodesCmdPalette = useSelector(showNodesCmdPaletteSelector);
   const dispatch = useDispatch();
+  const dialogRef = React.useRef<HTMLDivElement>(null);
   const cursorPositionRef = React.useRef<{ x: number; y: number }>({
     x: 0,
     y: 0,
@@ -140,8 +141,29 @@ const CommandMenu = ({ items, handleSelectNewNodeType }: ICommandMenu) => {
     }
   };
 
+  // add click outside handler
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dialogRef.current &&
+        !dialogRef.current.contains(event.target as HTMLElement)
+      ) {
+        dispatch.ui.setShowNodesCmdPalette(false);
+      }
+    };
+
+    if (showNodesCmdPalette) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showNodesCmdPalette, dispatch.ui]);
+
   return (
     <Command.Dialog
+      ref={dialogRef}
       open={showNodesCmdPalette}
       onOpenChange={() =>
         dispatch.ui.setShowNodesCmdPalette(!showNodesCmdPalette)


### PR DESCRIPTION
# Description

* fixed not being able to click out of command palette

Fixes #541

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Video

![51b9cf7e-79fe-4195-bb2c-218b6253fde4](https://github.com/user-attachments/assets/68794b7f-0f0d-402e-8acf-e77738cddfe3)

