### PR TITLE
Fix breaking Id issue from preview feature

### DIFF
--- a/packages/graph-editor/src/data/version.ts
+++ b/packages/graph-editor/src/data/version.ts
@@ -1,1 +1,1 @@
-export const version = '4.3.11';
+export const version = '4.3.12';

--- a/packages/graph-editor/src/editor/layoutController.tsx
+++ b/packages/graph-editor/src/editor/layoutController.tsx
@@ -225,17 +225,16 @@ const defaultLayout: LayoutBase = {
 };
 
 const layoutLoader = (tab: TabBase, props, ref): TabData => {
-  const { id, ...rest } = tab;
+  const { id } = tab;
 
   switch (id) {
     case 'graphs':
       return {
-        id: 'graphs',
         //@ts-expect-error
         size: 700,
         group: 'graph',
         panelLock: { panelStyle: 'graph' },
-        ...rest,
+        ...tab,
       };
     case MAIN_GRAPH_ID:
       return {
@@ -248,6 +247,7 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
             <GraphEditor {...props} id={MAIN_GRAPH_ID} ref={ref} />
           </ErrorBoundary>
         ),
+        ...tab
       };
 
     case 'input':
@@ -255,32 +255,31 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
         closable: true,
         cached: true,
         group: 'popout',
-        id: 'input',
         title: 'Inputs',
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
             <Inputsheet />
           </ErrorBoundary>
         ),
+        ...tab
       };
     case 'outputs':
       return {
         closable: true,
         cached: true,
         group: 'popout',
-        id: 'outputs',
         title: 'Outputs',
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
             <OutputSheet />
           </ErrorBoundary>
         ),
+        ...tab
       };
 
     case 'dropPanel':
       return {
         group: 'popout',
-        id: 'dropPanel',
         title: 'Nodes',
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
@@ -288,6 +287,7 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
           </ErrorBoundary>
         ),
         closable: true,
+        ...tab
       };
 
     default:

--- a/packages/graph-editor/src/editor/layoutController.tsx
+++ b/packages/graph-editor/src/editor/layoutController.tsx
@@ -247,7 +247,7 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
             <GraphEditor {...props} id={MAIN_GRAPH_ID} ref={ref} />
           </ErrorBoundary>
         ),
-        ...tab
+        ...tab,
       };
 
     case 'input':
@@ -261,7 +261,7 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
             <Inputsheet />
           </ErrorBoundary>
         ),
-        ...tab
+        ...tab,
       };
     case 'outputs':
       return {
@@ -274,7 +274,7 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
             <OutputSheet />
           </ErrorBoundary>
         ),
-        ...tab
+        ...tab,
       };
 
     case 'dropPanel':
@@ -287,7 +287,7 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
           </ErrorBoundary>
         ),
         closable: true,
-        ...tab
+        ...tab,
       };
 
     default:


### PR DESCRIPTION
### **User description**
Fixes an issue where the input / panels permanent lost access to the outer graph instance


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed issue with `id` handling in `layoutLoader`.

- Ensured `tab` properties are correctly spread in cases.

- Removed redundant `id` assignments in specific cases.

- Improved consistency in `layoutLoader` function logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layoutController.tsx</strong><dd><code>Fix `id` handling and refine `layoutLoader` logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/layoutController.tsx

<li>Fixed <code>id</code> handling by removing redundant assignments.<br> <li> Ensured <code>tab</code> properties are spread consistently across cases.<br> <li> Improved logic for <code>layoutLoader</code> function.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/644/files#diff-60d8069b739deeb69c0c06a98fabfccd34dca2ef65e06c4aa8d76603ca6e1af3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information