### PR TITLE
Fix graph editor caching issue

### DIFF
--- a/.changeset/two-carpets-kneel.md
+++ b/.changeset/two-carpets-kneel.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": minor
+---
+
+Fix editor caching issue

--- a/packages/graph-editor/src/editor/layoutController.tsx
+++ b/packages/graph-editor/src/editor/layoutController.tsx
@@ -242,12 +242,12 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
         cached: true,
         group: 'graph',
         title: 'Graph',
+        ...tab,
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
             <GraphEditor {...props} id={MAIN_GRAPH_ID} ref={ref} />
           </ErrorBoundary>
         ),
-        ...tab,
       };
 
     case 'input':
@@ -256,12 +256,12 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
         cached: true,
         group: 'popout',
         title: 'Inputs',
+        ...tab,
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
             <Inputsheet />
           </ErrorBoundary>
         ),
-        ...tab,
       };
     case 'outputs':
       return {
@@ -269,25 +269,25 @@ const layoutLoader = (tab: TabBase, props, ref): TabData => {
         cached: true,
         group: 'popout',
         title: 'Outputs',
+        ...tab,
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
             <OutputSheet />
           </ErrorBoundary>
         ),
-        ...tab,
       };
 
     case 'dropPanel':
       return {
         group: 'popout',
         title: 'Nodes',
+        ...tab,
         content: (
           <ErrorBoundary fallback={<ErrorBoundaryContent />}>
             <DropPanel />
           </ErrorBoundary>
         ),
         closable: true,
-        ...tab,
       };
 
     default:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed caching issue in `layoutLoader` function for graph editor.

- Adjusted the spread operator placement for `tab` object.

- Added a changeset file to document the fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layoutController.tsx</strong><dd><code>Fix caching issue in layoutLoader function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/layoutController.tsx

<li>Fixed caching issue by repositioning the spread operator for <code>tab</code>.<br> <li> Ensured consistent behavior for different tab types in <code>layoutLoader</code>.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/648/files#diff-60d8069b739deeb69c0c06a98fabfccd34dca2ef65e06c4aa8d76603ca6e1af3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>two-carpets-kneel.md</strong><dd><code>Add changeset for caching issue fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/two-carpets-kneel.md

- Added a changeset file to document the caching fix.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/648/files#diff-55b3efe0f6d02f5f29d192216ec3e506d586146297808cbe4ef93d6eff51dffd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>