### PR TITLE
use loader in subgraphs

### DIFF
--- a/.changeset/rich-ducks-retire.md
+++ b/.changeset/rich-ducks-retire.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-engine": patch
+---
+
+Use external loader in subgraphs (ThemeNode and Static sets will now load in subgraphs)

--- a/packages/graph-engine/src/nodes/array/arraySubgraph.ts
+++ b/packages/graph-engine/src/nodes/array/arraySubgraph.ts
@@ -42,6 +42,11 @@ export default class ArraySubgraph<T, V> extends Node {
 		const existing = !!props.innerGraph;
 		this._innerGraph = props.innerGraph || new Graph();
 
+		// Automatically propagate the parent’s loader, if any
+		if (props.graph?.externalLoader) {
+			this._innerGraph.externalLoader = props.graph.externalLoader;
+		}
+
 		let input: InputNode;
 
 		if (!existing) {

--- a/packages/graph-engine/src/nodes/generic/subgraph.ts
+++ b/packages/graph-engine/src/nodes/generic/subgraph.ts
@@ -33,6 +33,11 @@ export default class SubgraphNode extends Node {
 		const existing = !!props.innergraph;
 		this._innerGraph = props.innergraph || new Graph();
 
+		// Automatically propagate the parent’s loader, if any
+		if (props.graph?.externalLoader) {
+			this._innerGraph.externalLoader = props.graph.externalLoader;
+		}
+
 		//Pass capabilities down
 		this._innerGraph.capabilities = this.getGraph().capabilities;
 

--- a/packages/graph-engine/tests/suites/graph/subgraph.test.ts
+++ b/packages/graph-engine/tests/suites/graph/subgraph.test.ts
@@ -1,0 +1,23 @@
+import { Graph } from '../../../src/graph/graph.js';
+import { describe, expect, it, vi } from 'vitest';
+import SubgraphNode from '../../../src/nodes/generic/subgraph.js';
+
+describe('SubgraphNode', () => {
+  it('should pass the parent externalLoader to the subgraph', async () => {
+    const graph = new Graph();
+
+    // Create a mock external loader
+    const mockExternalLoader = vi.fn(async () => {
+      return 'external value';
+    });
+
+    // Set it on the parent graph
+    graph.externalLoader = mockExternalLoader;
+
+    // Create a SubgraphNode (which should inherit the loader)
+    const subgraphNode = new SubgraphNode({ graph });
+
+    // Ensure the _innerGraph now has the same externalLoader
+    expect(subgraphNode._innerGraph.externalLoader).toBe(mockExternalLoader);
+  });
+}); 

--- a/packages/graph-engine/tests/suites/graph/subgraph.test.ts
+++ b/packages/graph-engine/tests/suites/graph/subgraph.test.ts
@@ -3,21 +3,21 @@ import { describe, expect, it, vi } from 'vitest';
 import SubgraphNode from '../../../src/nodes/generic/subgraph.js';
 
 describe('SubgraphNode', () => {
-  it('should pass the parent externalLoader to the subgraph', async () => {
-    const graph = new Graph();
+	it('should pass the parent externalLoader to the subgraph', async () => {
+		const graph = new Graph();
 
-    // Create a mock external loader
-    const mockExternalLoader = vi.fn(async () => {
-      return 'external value';
-    });
+		// Create a mock external loader
+		const mockExternalLoader = vi.fn(async () => {
+			return 'external value';
+		});
 
-    // Set it on the parent graph
-    graph.externalLoader = mockExternalLoader;
+		// Set it on the parent graph
+		graph.externalLoader = mockExternalLoader;
 
-    // Create a SubgraphNode (which should inherit the loader)
-    const subgraphNode = new SubgraphNode({ graph });
+		// Create a SubgraphNode (which should inherit the loader)
+		const subgraphNode = new SubgraphNode({ graph });
 
-    // Ensure the _innerGraph now has the same externalLoader
-    expect(subgraphNode._innerGraph.externalLoader).toBe(mockExternalLoader);
-  });
-}); 
+		// Ensure the _innerGraph now has the same externalLoader
+		expect(subgraphNode._innerGraph.externalLoader).toBe(mockExternalLoader);
+	});
+});

--- a/packages/graph-engine/tests/suites/nodes/array/arrayMap.test.ts
+++ b/packages/graph-engine/tests/suites/nodes/array/arrayMap.test.ts
@@ -3,21 +3,23 @@ import { describe, expect, it, vi } from 'vitest';
 import ArraySubgraph from '../../../../src/nodes/array/arraySubgraph.js';
 
 describe('ArraySubgraph', () => {
-  it('should pass the parent externalLoader to the inner graph', async () => {
-    const graph = new Graph();
+	it('should pass the parent externalLoader to the inner graph', async () => {
+		const graph = new Graph();
 
-    // Create a mock external loader
-    const mockExternalLoader = vi.fn(async () => {
-      return 'external value';
-    });
+		// Create a mock external loader
+		const mockExternalLoader = vi.fn(async () => {
+			return 'external value';
+		});
 
-    // Set it on the parent graph
-    graph.externalLoader = mockExternalLoader;
+		// Set it on the parent graph
+		graph.externalLoader = mockExternalLoader;
 
-    // Create an ArraySubgraph node (which should inherit the loader)
-    const arraySubgraphNode = new ArraySubgraph({ graph });
+		// Create an ArraySubgraph node (which should inherit the loader)
+		const arraySubgraphNode = new ArraySubgraph({ graph });
 
-    // Ensure the _innerGraph now has the same externalLoader
-    expect(arraySubgraphNode._innerGraph.externalLoader).toBe(mockExternalLoader);
-  });
+		// Ensure the _innerGraph now has the same externalLoader
+		expect(arraySubgraphNode._innerGraph.externalLoader).toBe(
+			mockExternalLoader
+		);
+	});
 });

--- a/packages/graph-engine/tests/suites/nodes/array/arrayMap.test.ts
+++ b/packages/graph-engine/tests/suites/nodes/array/arrayMap.test.ts
@@ -1,0 +1,23 @@
+import { Graph } from '../../../../src/graph/graph.js';
+import { describe, expect, it, vi } from 'vitest';
+import ArraySubgraph from '../../../../src/nodes/array/arraySubgraph.js';
+
+describe('ArraySubgraph', () => {
+  it('should pass the parent externalLoader to the inner graph', async () => {
+    const graph = new Graph();
+
+    // Create a mock external loader
+    const mockExternalLoader = vi.fn(async () => {
+      return 'external value';
+    });
+
+    // Set it on the parent graph
+    graph.externalLoader = mockExternalLoader;
+
+    // Create an ArraySubgraph node (which should inherit the loader)
+    const arraySubgraphNode = new ArraySubgraph({ graph });
+
+    // Ensure the _innerGraph now has the same externalLoader
+    expect(arraySubgraphNode._innerGraph.externalLoader).toBe(mockExternalLoader);
+  });
+});


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Automatically propagate parent loader to subgraphs.

- Updated `ArraySubgraph` and `SubgraphNode` constructors.

- Added changeset for external loader usage in subgraphs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arraySubgraph.ts</strong><dd><code>Propagate external loader in `ArraySubgraph`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-engine/src/nodes/array/arraySubgraph.ts

<li>Added logic to propagate parent loader to <code>ArraySubgraph</code>.<br> <li> Ensures <code>externalLoader</code> is passed to the inner graph.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/653/files#diff-d9c15c32d34d0e0a11b65b351ba4fb36958ed9ce01526410c60af779baab6b6c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subgraph.ts</strong><dd><code>Propagate external loader in `SubgraphNode`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-engine/src/nodes/generic/subgraph.ts

<li>Added logic to propagate parent loader to <code>SubgraphNode</code>.<br> <li> Ensures <code>externalLoader</code> is passed to the inner graph.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/653/files#diff-f5c1a0ca6c8b3ed2623a20e1596b3293fef42f458ea0ba03325a31b676e67512">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rich-ducks-retire.md</strong><dd><code>Document external loader usage in subgraphs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/rich-ducks-retire.md

<li>Added changeset to document external loader usage in subgraphs.<br> <li> Highlights impact on <code>ThemeNode</code> and static sets.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/653/files#diff-b12521cd06b8578f581250d471a4ef5e3092e41e698080cfe15e6fadd7f38cad">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>