### PR TITLE
fixed MMB pan incorrectly selecting nodes and edges

### DIFF
--- a/.changeset/violet-wasps-learn.md
+++ b/.changeset/violet-wasps-learn.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fixed MMB pan selecting nodes and edges

--- a/packages/graph-editor/src/editor/graph.tsx
+++ b/packages/graph-editor/src/editor/graph.tsx
@@ -701,6 +701,14 @@ export const EditorApp = React.forwardRef<
     nodeLookup: fullNodeLookup,
   });
 
+  const onMouseDownCapture = (event) => {
+    if (event.button === 1) {
+      // MMB pan without selecting nodes or edges
+      event.preventDefault();
+      return false;
+    }
+  };
+
   const copyNodes = copyNodeAction(reactFlowInstance, graph, fullNodeLookup);
   const selectAddedNodes = useSelectAddedNodes();
 
@@ -757,6 +765,7 @@ export const EditorApp = React.forwardRef<
               ref={reactFlowWrapper}
               elevateEdgesOnSelect={true}
               nodes={nodes}
+              onMouseDownCapture={onMouseDownCapture}
               onNodesChange={managedNodesChange}
               onEdgesChange={managedEdgeChange}
               onEdgeDoubleClick={onEdgeDblClick}


### PR DESCRIPTION
### **User description**
# Description

* fixed MMB pan incorrectly selecting nodes and edges

Fixes #637

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Video

![76055bdb-0acf-48a6-890b-263953e3c2a6](https://github.com/user-attachments/assets/d4349d06-3639-4dc8-9ed2-5a6fec085e6c)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed issue where MMB pan selected nodes and edges.

- Added `onMouseDownCapture` to prevent unintended selection.

- Updated ReactFlow component to include `onMouseDownCapture`.

- Added changeset entry for the bug fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graph.tsx</strong><dd><code>Prevent selection during MMB pan in graph editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/editor/graph.tsx

<li>Added <code>onMouseDownCapture</code> to handle MMB pan without selection.<br> <li> Integrated <code>onMouseDownCapture</code> into ReactFlow component.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/654/files#diff-0a5251be74b5e25cb4df55d09e1906b29f32d52ea95168b26c72ccfdd66d2c30">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>violet-wasps-learn.md</strong><dd><code>Documented MMB pan bug fix in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/violet-wasps-learn.md

- Added a changeset entry for the MMB pan bug fix.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/654/files#diff-1d1ed9e118fc28e9ab71342fb038035e2ca287c64824f3ec673ee17627befcc8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>