### PR TITLE
fixed bottom padding on passthrough node

### DIFF
--- a/packages/graph-editor/src/components/flow/handles.module.css
+++ b/packages/graph-editor/src/components/flow/handles.module.css
@@ -2,13 +2,17 @@
   position: relative;
   display: flex;
   align-items: center;
-  padding: var(--component-spacing-2xs) var(--component-spacing-md);
-  margin-bottom: var(--component-spacing-xs);
+  padding: 0 var(--component-spacing-md);
+  min-height: var(--component-spacing-md);
 
-  &:not(:has(.handleText, span)) {
-    margin-bottom: var(--component-spacing-lg);
+  & + & {
+    margin-top: var(--component-spacing-md);
   }
 
+  &:last-child:not(:first-child) {
+    margin-bottom: var(--component-spacing-md);
+  }
+  
   &.collapsed {
     height: 0;
     overflow: hidden;


### PR DESCRIPTION
### **User description**
# Description

* fixed uneven bottom padding on passthrough node

Fixes #655

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshot

![image](https://github.com/user-attachments/assets/17aa4c8f-a5be-4320-8ac2-59802bff8c6d)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed uneven bottom padding in `passthrough` node.

- Adjusted padding and margin styles for better alignment.

- Ensured consistent spacing between `handleHolder` elements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handles.module.css</strong><dd><code>Fix padding and margin issues in `handleHolder`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/handles.module.css

<li>Adjusted padding to remove uneven bottom spacing.<br> <li> Added <code>min-height</code> for consistent height.<br> <li> Modified margin rules for better spacing between elements.<br> <li> Ensured proper handling of last-child elements.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/656/files#diff-549392e0d4516a50dc42d029eeffc71c01a6602a6e92f4ffa9973f08547f0ac0">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>