### PR TITLE
fixed incorrect empty URI error in ExternalSet

### DIFF
--- a/packages/nodes-design-tokens/src/nodes/externalTokens.ts
+++ b/packages/nodes-design-tokens/src/nodes/externalTokens.ts
@@ -26,7 +26,8 @@ export default class ExternalTokensNode extends Node {
 		const { uri } = this.getAllInputs();
 
 		if (!uri) {
-			throw new Error('No uri specified');
+			this.outputs.tokenSet.set([]);
+			return;
 		}
 
 		const tokens = await this.load(uri);


### PR DESCRIPTION
### **User description**
# Description

* fixed incorrect empty URI error in ExternalSet node

Related to https://github.com/tokens-studio/studio-app/pull/2137
Fixes #2136

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Video

![5f163ac4-c33b-439b-8152-873839d36189](https://github.com/user-attachments/assets/20bee1ed-e3ef-4820-9dfb-97bedad2bf40)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed handling of empty `uri` in `ExternalTokensNode`.

- Prevented error by setting empty token set when `uri` is missing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>externalTokens.ts</strong><dd><code>Handle missing `uri` in `ExternalTokensNode`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nodes-design-tokens/src/nodes/externalTokens.ts

<li>Modified <code>execute</code> method to handle missing <code>uri</code>.<br> <li> Replaced error throw with setting an empty token set.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/658/files#diff-2216247be59077793b26fffa769af7739e5b0fc4c07c09e54ad01ad67d19eb47">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>