### PR TITLE
add create reference node

### DIFF
--- a/.changeset/breezy-moose-cough.md
+++ b/.changeset/breezy-moose-cough.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-engine-nodes-design-tokens": minor
+---
+
+We added the Create Reference node which makes it easier to create a reference string from other strings, you are able to just add a string per segment and it wraps it in {} and adds the . as seperator

--- a/packages/nodes-design-tokens/src/nodes/createReference.ts
+++ b/packages/nodes-design-tokens/src/nodes/createReference.ts
@@ -1,0 +1,56 @@
+import {
+	INodeDefinition,
+	Node,
+	StringSchema,
+	ToInput,
+	ToOutput,
+	createVariadicSchema
+} from '@tokens-studio/graph-engine';
+
+export default class CreateReferenceNode extends Node {
+	static title = 'Create Reference';
+	static type = 'studio.tokens.design.createReference';
+	static description =
+		'Creates a design token reference by joining path segments with dots and wrapping in curly braces.';
+
+	declare inputs: ToInput<{
+		segments: string[];
+	}>;
+	declare outputs: ToOutput<{
+		reference: string;
+	}>;
+
+	constructor(props: INodeDefinition) {
+		super(props);
+
+		this.addInput('segments', {
+			type: {
+				...createVariadicSchema(StringSchema),
+				default: []
+			},
+			variadic: true
+		});
+
+		this.addOutput('reference', {
+			type: StringSchema
+		});
+
+		// Listen for edge removals on the graph
+		if (props.graph) {
+			props.graph.on('edgeRemoved', () => {
+				this.execute();
+			});
+		}
+	}
+
+	execute(): void {
+		// Get the current value or fall back to default empty array
+		const segments = this.inputs.segments.value ?? [];
+
+		// Always set the output, even if empty
+		const reference = segments.length > 0 ? `{${segments.join('.')}}` : '';
+
+		// Ensure we always set the output value
+		this.outputs.reference.set(reference);
+	}
+}

--- a/packages/nodes-design-tokens/src/nodes/index.ts
+++ b/packages/nodes-design-tokens/src/nodes/index.ts
@@ -4,6 +4,7 @@ import CreateBorderNode from './createBorder.js';
 import CreateBorderTokenNode from './createBorderToken.js';
 import CreateBoxShadowNode from './createBoxShadow.js';
 import CreateBoxShadowTokenNode from './createBoxShadowToken.js';
+import CreateReferenceNode from './createReference.js';
 import CreateTypographyNode from './createTypography.js';
 import CreateTypographyTokenNode from './createTypographyToken.js';
 import DestructNode from './destructToken.js';
@@ -39,6 +40,7 @@ export const nodes: (typeof Node)[] = ([] as (typeof Node)[]).concat(
 	CreateBorderTokenNode,
 	CreateTypographyTokenNode,
 	create,
+	CreateReferenceNode,
 	DestructNode,
 	InlineTokenNode,
 	FlattenNode,

--- a/packages/nodes-design-tokens/tests/createReference.test.ts
+++ b/packages/nodes-design-tokens/tests/createReference.test.ts
@@ -1,0 +1,65 @@
+import { Graph, StringSchema, nodeLookup } from '@tokens-studio/graph-engine';
+import { describe, expect, test } from 'vitest';
+import CreateReferenceNode from '../src/nodes/createReference.js';
+
+const ConstantNode = nodeLookup['studio.tokens.generic.constant'];
+
+describe('naming/createReference', () => {
+	test('exports an empty string by default', async () => {
+		const graph = new Graph();
+		const node = new CreateReferenceNode({ graph });
+
+		await node.execute();
+
+		const actual = node.outputs.reference.value;
+
+		expect(actual).toBe('');
+		expect(node.outputs.reference.type).toBe(StringSchema);
+	});
+
+	test('creates a reference from multiple segments', async () => {
+		const graph = new Graph();
+		const node = new CreateReferenceNode({ graph });
+
+		const segment1 = new ConstantNode({ graph });
+		segment1.inputs.value.setValue('colors', {
+			type: StringSchema
+		});
+
+		const segment2 = new ConstantNode({ graph });
+		segment2.inputs.value.setValue('primary', {
+			type: StringSchema
+		});
+
+		const segment3 = new ConstantNode({ graph });
+		segment3.inputs.value.setValue('500', {
+			type: StringSchema
+		});
+
+		segment1.outputs.value.connect(node.inputs.segments);
+		segment2.outputs.value.connect(node.inputs.segments);
+		segment3.outputs.value.connect(node.inputs.segments);
+
+		await node.execute();
+
+		const actual = node.outputs.reference.value;
+
+		expect(actual).toBe('{colors.primary.500}');
+	});
+
+	test('handles single segment reference', async () => {
+		const graph = new Graph();
+		const node = new CreateReferenceNode({ graph });
+
+		const segment = new ConstantNode({ graph });
+		segment.inputs.value.setValue('colors', {
+			type: StringSchema
+		});
+
+		segment.outputs.value.connect(node.inputs.segments);
+
+		await node.execute();
+
+		expect(node.outputs.reference.value).toBe('{colors}');
+	});
+});


### PR DESCRIPTION
Adds a create reference node that makes it easier for the user to create token references, you have a variadic input for an array of strings, that are then joined with a `.` as separator and wrapped in `{}`

![CleanShot 2025-02-21 at 10 15 27@2x](https://github.com/user-attachments/assets/1e874e34-f86a-4937-b5b4-b5c2ae3dee42)
