### PR TITLE
fixed variadic input style

### DIFF
--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -333,7 +333,16 @@ const InputHandle = observer(
             id={port.name}
             variadic
           >
-            {!hideName && <Text>{port.name} + </Text>}
+            {!hideName && (
+              <span
+                style={{
+                  font: 'var(--font-code-lg)',
+                  color: 'var(--color-neutral-1500)',
+                }}
+              >
+                {port.name} +
+              </span>
+            )}
             {inlineTypesValue && <InlineTypeLabel port={port} />}
           </Handle>
           {port._edges.map((edge, i) => {

--- a/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
+++ b/packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx
@@ -337,7 +337,7 @@ const InputHandle = observer(
               <span
                 style={{
                   font: 'var(--font-code-lg)',
-                  color: 'var(--color-neutral-1500)',
+                  color: 'var(--fg-default)',
                 }}
               >
                 {port.name} +
@@ -405,7 +405,7 @@ const InputHandle = observer(
             <span
               style={{
                 font: 'var(--font-code-lg)',
-                color: 'var(--color-neutral-1500)',
+                color: 'var(--fg-default)',
               }}
             >
               {input.name}
@@ -413,7 +413,7 @@ const InputHandle = observer(
             {inlineValuesValue && (
               <span
                 style={{
-                  font: 'var(--font-code-xs)',
+                  font: 'var(--font-code-md)',
                   color: 'var(--color-neutral-1200)',
                 }}
               >


### PR DESCRIPTION
### **User description**
# Description

* unified variadic input style with other port styles

Fixes #671

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![image](https://github.com/user-attachments/assets/58f14cb1-fea7-4b20-ac49-ec44ccd7b101)
![image](https://github.com/user-attachments/assets/6ac14ddc-4ca5-4c4e-8aa6-9013ba2e5511)


___

### **PR Type**
- Bug fix



___

### **Description**
- Replaced Text component with styled span.

- Applied specific font and color styles.

- Unified variadic input style with other ports.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodeV2.tsx</strong><dd><code>Update variadic input text styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/flow/wrapper/nodeV2.tsx

<li>Changed <Text> component to <span> element.<br> <li> Added inline style for font and color.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/672/files#diff-22c64f79290285f9b5524bf34746fe5aba1d1ef1100277adfd1fd2403621c07d">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>