### PR TITLE
fixed Color Blindness node always returning 000

### DIFF
--- a/.changeset/thin-tigers-agree.md
+++ b/.changeset/thin-tigers-agree.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-engine": patch
+---
+
+fixed Color Blindness node always returning #000

--- a/packages/graph-engine/src/nodes/accessibility/colorBlindness.ts
+++ b/packages/graph-engine/src/nodes/accessibility/colorBlindness.ts
@@ -75,29 +75,29 @@ export default class NodeDefinition extends Node {
 
 		switch (type) {
 			case ColorBlindnessTypes.TRITANOPIA:
-				processed = blinder.tritanopia(color);
+				processed = blinder.tritanopia(processed);
 				break;
 			case ColorBlindnessTypes.TRITANOMALY:
-				processed = blinder.tritanomaly(color);
+				processed = blinder.tritanomaly(processed);
 				break;
 			case ColorBlindnessTypes.DEUTERANOPIA:
-				processed = blinder.deuteranopia(color);
+				processed = blinder.deuteranopia(processed);
 				break;
 			case ColorBlindnessTypes.DEUTERANOMALY:
-				processed = blinder.deuteranomaly(color);
+				processed = blinder.deuteranomaly(processed);
 				break;
 
 			case ColorBlindnessTypes.PROTANOMALY:
-				processed = blinder.protanomaly(color);
+				processed = blinder.protanomaly(processed);
 				break;
 			case ColorBlindnessTypes.ACHROMATOPSIA:
-				processed = blinder.achromatopsia(color);
+				processed = blinder.achromatopsia(processed);
 				break;
 			case ColorBlindnessTypes.ACHROMATOMALY:
-				processed = blinder.achromatomaly(color);
+				processed = blinder.achromatomaly(processed);
 				break;
 			default:
-				processed = blinder.protanopia(color);
+				processed = blinder.protanopia(processed);
 				break;
 		}
 


### PR DESCRIPTION
### **User description**
# Description

* fixed Color Blindness node returning #000 for all colors

Fixes #678
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshot

![image](https://github.com/user-attachments/assets/035946af-ada7-48a1-9b24-2ebe24484afe)


___

### **PR Type**
- Bug fix



___

### **Description**
- Use processed hex value for color blind simulations.

- Update changeset with patch version information.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>colorBlindness.ts</strong><dd><code>Pass processed color to blinder functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-engine/src/nodes/accessibility/colorBlindness.ts

<li>Replace raw color with processed hex value.<br> <li> Ensures consistency in color conversion.<br> <li> Updates blinder function parameters.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/679/files#diff-bf2653f2de5cc30083e215c09b8905ee7d3be475462eae12216038060ca3997b">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>thin-tigers-agree.md</strong><dd><code>Add changeset for patch version.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/thin-tigers-agree.md

<li>Add changeset file with patch update.<br> <li> Document fix for Color Blindness node.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/679/files#diff-1ad9d73869a4429ae35c971ea99ace89f0443ff8eb3f49432a9fad82f86a6287">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>