### PR TITLE
Prevent browser back navigation from trackpad gestures

### DIFF
--- a/.changeset/brown-lobsters-invent.md
+++ b/.changeset/brown-lobsters-invent.md
@@ -1,0 +1,8 @@
+---
+"@tokens-studio/graph-editor": patch
+"@tokens-studio/graph-engine-ui": patch
+---
+
+Fixed: Accidental Browser Navigation on macOS
+
+Fixed an issue where horizontal swipe gestures on trackpads/Magic Mouse would accidentally trigger browser back/forward navigation while working on the canvas. You can now work with your graphs without unexpected navigation issues.

--- a/packages/graph-editor/src/css/reactflow.css
+++ b/packages/graph-editor/src/css/reactflow.css
@@ -3,6 +3,7 @@
 
 .react-flow {
     background: var(--color-neutral-canvas-minimal-bg);
+    overscroll-behavior-x: none; /* Prevent browser back/forward navigation */
 }
 
 .react-flow__node {

--- a/packages/graph-editor/src/editor/graph.tsx
+++ b/packages/graph-editor/src/editor/graph.tsx
@@ -757,6 +757,7 @@ export const EditorApp = React.forwardRef<
             display: 'flex',
             flexDirection: 'row',
             flexGrow: 1,
+            overscrollBehaviorX: 'none',
           }}
         >
           <HotKeys>

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -19,6 +19,7 @@ body {
   height: 100vh;
   color: var(--color-neutral-canvas-default-fg-default);
   background: var(--color-neutral-canvas-default-bg);
+  overscroll-behavior-x: none; /* Prevent browser back/forward navigation */
 }
 
 


### PR DESCRIPTION
**Fix: Prevent browser back navigation from trackpad gestures**

Applied `overscroll-behavior-x: none` at multiple levels to prevent browser navigation from trackpad gestures while preserving canvas panning functionality. Tested on Chrome, Safari, and Firefox on macOS.
