### PR TITLE
Prevent infinite zooming and negative zoom crashes in graph editor

### DIFF
--- a/.changeset/kind-dingos-trade.md
+++ b/.changeset/kind-dingos-trade.md
@@ -1,0 +1,7 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Fixed: Infinite Zooming and Negative Zoom Crashes
+
+Fixed an issue where rapidly scrolling the mouse wheel could cause the graph editor to freeze or crash. The graph canvas now has proper zoom limits (10% to 1000%) to ensure stable performance and prevent application freezes when working with complex graphs.

--- a/packages/graph-editor/src/components/hotKeys/index.tsx
+++ b/packages/graph-editor/src/components/hotKeys/index.tsx
@@ -208,12 +208,20 @@ export const useHotkeys = () => {
       ZOOM_IN: (event) => {
         event.stopPropagation();
         event.preventDefault();
-        reactFlowInstance.zoomIn({ duration: 300 });
+        const viewport = reactFlowInstance.getViewport();
+        // Don't allow zooming beyond max zoom
+        if (viewport.zoom < 10) {
+          reactFlowInstance.zoomIn({ duration: 300 });
+        }
       },
       ZOOM_OUT: (event) => {
         event.preventDefault();
         event.stopPropagation();
-        reactFlowInstance.zoomOut({ duration: 300 });
+        const viewport = reactFlowInstance.getViewport();
+        // Don't allow zooming below min zoom
+        if (viewport.zoom > 0.1) {
+          reactFlowInstance.zoomOut({ duration: 300 });
+        }
       },
       RESET_ZOOM: () => {
         const existing = reactFlowInstance.getViewport();

--- a/packages/graph-editor/src/components/toolbar/dropdowns/zoom.tsx
+++ b/packages/graph-editor/src/components/toolbar/dropdowns/zoom.tsx
@@ -31,8 +31,10 @@ export const ZoomDropdown = () => {
   const onSetZoom = useCallback(
     (e) => {
       const zoom = parseFloat(e.currentTarget.dataset.value);
+      // Ensure zoom is within valid range
+      const safeZoom = Math.max(0.1, Math.min(zoom, 10));
 
-      reactFlow.zoomTo(zoom, {
+      reactFlow.zoomTo(safeZoom, {
         duration: 0.1,
       });
     },
@@ -41,12 +43,14 @@ export const ZoomDropdown = () => {
 
   const zoomIn = useCallback(() => {
     const viewport = reactFlow.getViewport();
-    reactFlow.setViewport({ ...viewport, zoom: viewport.zoom + 0.1 });
+    const newZoom = Math.min(viewport.zoom + 0.1, 10); // Cap at max zoom
+    reactFlow.setViewport({ ...viewport, zoom: newZoom });
   }, [reactFlow]);
 
   const zoomOut = useCallback(() => {
     const viewport = reactFlow.getViewport();
-    reactFlow.setViewport({ ...viewport, zoom: viewport.zoom - 0.1 });
+    const newZoom = Math.max(viewport.zoom - 0.1, 0.1); // Prevent going below min zoom
+    reactFlow.setViewport({ ...viewport, zoom: newZoom });
   }, [reactFlow]);
 
   const onSaveViewPort = useCallback(

--- a/packages/graph-editor/src/data/version.ts
+++ b/packages/graph-editor/src/data/version.ts
@@ -1,1 +1,1 @@
-export const version = '4.3.12';
+export const version = '4.4.1';

--- a/packages/graph-editor/src/editor/graph.tsx
+++ b/packages/graph-editor/src/editor/graph.tsx
@@ -800,11 +800,11 @@ export const EditorApp = React.forwardRef<
               onDragOver={onDragOver}
               selectionOnDrag={true}
               panOnDrag={panOnDrag}
-              minZoom={-Infinity}
+              minZoom={0.1}
               zoomOnDoubleClick={false}
               defaultViewport={defaultViewport}
               onlyRenderVisibleElements={true}
-              maxZoom={Infinity}
+              maxZoom={10}
               proOptions={proOptions}
             >
               {showGridValue && (


### PR DESCRIPTION
This PR addresses the issue where rapid mouse wheel scrolling could cause the graph editor to enter an infinite zooming state, leading to application freezes with the zoom level displayed as "0%".

### Implementation Details

The solution implements consistent min/max zoom constraints (0.1 - 10) across all zoom-related functionality in the application:

1. Applied constraints to ReactFlow component props to establish system-wide bounds
2. Added validation in toolbar zoom-related functions to enforce limits
3. Updated hotkey handlers to check current zoom before allowing further zooming

This comprehensive approach protects all zoom entry points while maintaining expected zoom behavior within reasonable bounds. The constraints prevent both negative zoom values (which cause rendering issues) and excessive zoom levels that can lead to performance problems.

### Testing

Tested across Chrome, Safari, and Firefox on macOS with both mouse wheel and keyboard shortcuts, confirming that:
- Rapidly scrolling the mouse wheel no longer causes freezing
- Zoom levels stay within the 10% to 1000% range
- All zoom controls (mouse wheel, keyboard shortcuts, UI buttons) correctly respect these limits

Fixes: #657 
