### PR TITLE
remove subgraph tabs when nodes deleted

### DIFF
--- a/.changeset/sour-views-shout.md
+++ b/.changeset/sour-views-shout.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Subgraph tabs are now removed when nodes containing the subgraphs are deleted.


### PR DESCRIPTION
# Description

* deleting a node with a subgraph now removes that subgraph's tab

Fixes #664

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to test this

![3f48479d-fe17-4fbb-9d1a-343f1e39cfb1](https://github.com/user-attachments/assets/fbf72108-376c-4759-b4c5-8435e07fe743)
