### PR TITLE
array fields now collapsed by default

### DIFF
--- a/.changeset/sixty-wasps-add.md
+++ b/.changeset/sixty-wasps-add.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/graph-editor": patch
+---
+
+Item arrays in outputs are now collapsed by default.

--- a/packages/graph-editor/src/components/controls/array.tsx
+++ b/packages/graph-editor/src/components/controls/array.tsx
@@ -68,7 +68,7 @@ export const ArrayField = observer(({ port, readOnly }: IField) => {
       <JSONTree
         data={{ items: toJS(value) }}
         hideRoot
-        shouldExpandNodeInitially={() => true}
+        shouldExpandNodeInitially={() => false}
       />
     );
   }, [value]);


### PR DESCRIPTION
### **User description**
# Description

* item arrays in node outputs are now collapsed by default

Fixes #554

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to test this

![c7bb1bee-d6fc-45bd-85f2-748f80b18192](https://github.com/user-attachments/assets/36e65dcb-336f-4773-99ad-da73a6fe719b)


___

### **PR Type**
- Enhancement



___

### **Description**
- Update JSONTree to collapse array fields by default.

- Add changeset file with patch note.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>array.tsx</strong><dd><code>Set JSONTree to not auto-expand arrays.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/graph-editor/src/components/controls/array.tsx

<li>Modified <code>shouldExpandNodeInitially</code> to return false.<br> <li> Ensures array fields are collapsed by default.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/693/files#diff-cd5220b1577f601c582b10abefda9561518afd1a4f84beebe922aca33d624c1b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sixty-wasps-add.md</strong><dd><code>Add changeset for collapsed item arrays.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/sixty-wasps-add.md

<li>Added changeset for patch update.<br> <li> Documents that item arrays are collapsed by default.


</details>


  </td>
  <td><a href="https://github.com/tokens-studio/graph-engine/pull/693/files#diff-8dd14fcdf006c3b3ed870566f78f490828b6c3d1e52195a441d37db479541345">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>